### PR TITLE
fix: health check catch SSH Error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "github-runner-manager"
-version = "0.1.1"
+version = "0.1.2"
 authors = [
     { name = "Canonical IS DevOps", email = "is-devops-team@canonical.com" },
 ]


### PR DESCRIPTION
Applicable spec: N/A

### Overview

- Catch SSH Error from health check logic.

### Rationale

- Regression

### Module Changes

- `openstack_runner_manager.py` - if the runner cannot be SSH-ed into (w/ SSH retries), it will mark the instance as unhealthy.

### Library/Dependency Changes

<!-- Any changes to libraries -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The library version in `pyproject.toml` is incremented

<!-- Explanation for any unchecked items above -->
