### PR TITLE
fix: instance initialization cloud-init status check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "github-runner-manager"
-version = "0.1.3"
+version = "0.1.4"
 authors = [
     { name = "Canonical IS DevOps", email = "is-devops-team@canonical.com" },
 ]

--- a/src/github_runner_manager/openstack_cloud/openstack_runner_manager.py
+++ b/src/github_runner_manager/openstack_cloud/openstack_runner_manager.py
@@ -590,12 +590,15 @@ class OpenStackRunnerManager(CloudRunnerManager):
         return OpenStackRunnerManager._run_health_check(ssh_conn, instance.server_name)
 
     @staticmethod
-    def _run_health_check(ssh_conn: SSHConnection, name: str) -> bool:
+    def _run_health_check(
+        ssh_conn: SSHConnection, name: str, accept_finished_job: bool = False
+    ) -> bool:
         """Run a health check for runner process.
 
         Args:
             ssh_conn: The SSH connection to the runner.
             name: The name of the runner.
+            accept_finished_job: Whether a job that has finished should be marked healthy.
 
         Returns:
             Whether the health succeed.
@@ -605,7 +608,7 @@ class OpenStackRunnerManager(CloudRunnerManager):
             logger.warning("cloud-init status command failed on %s: %s.", name, result.stderr)
             return False
         if CloudInitStatus.DONE in result.stdout:
-            return False
+            return accept_finished_job
         result = ssh_conn.run("ps aux", warn=True)
         if not result.ok:
             logger.warning("SSH run of `ps aux` failed on %s: %s", name, result.stderr)
@@ -636,7 +639,15 @@ class OpenStackRunnerManager(CloudRunnerManager):
                 "not completed"
             ) from err
 
-        result: invoke.runners.Result = ssh_conn.run("ps aux", warn=True)
+        result: invoke.runners.Result = ssh_conn.run("cloud-init status", warn=True)
+        if not result.ok:
+            logger.warning(
+                "cloud-init status command failed on %s: %s.", instance.server_name, result.stderr
+            )
+            raise RunnerStartError(f"Runner startup process not found on {instance.server_name}")
+        if CloudInitStatus.DONE in result.stdout:
+            return
+        result = ssh_conn.run("ps aux", warn=True)
         if not result.ok:
             logger.warning("SSH run of `ps aux` failed on %s", instance.server_name)
             raise RunnerStartError(f"Unable to SSH run `ps aux` on {instance.server_name}")
@@ -662,7 +673,9 @@ class OpenStackRunnerManager(CloudRunnerManager):
                 f"Failed to SSH connect to {instance.server_name} openstack runner"
             ) from err
 
-        if not self._run_health_check(ssh_conn=ssh_conn, name=instance.server_name):
+        if not self._run_health_check(
+            ssh_conn=ssh_conn, name=instance.server_name, accept_finished_job=True
+        ):
             logger.info("Runner process not found on %s", instance.server_name)
             raise RunnerStartError(
                 f"Runner process on {instance.server_name} failed to initialize on after starting"


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Also include cloud-init status check for when instantiating runners on wait_runner checks.

### Rationale

Fixes issue with short running jobs already being done before health checks.

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library/Dependency Changes

<!-- Any changes to libraries -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The library version in `pyproject.toml` is incremented

<!-- Explanation for any unchecked items above -->
