### PR TITLE
use url instead of job_url in JobDetails

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "github-runner-manager"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
     { name = "Canonical IS DevOps", email = "is-devops-team@canonical.com" },
 ]

--- a/src-docs/reactive.consumer.md
+++ b/src-docs/reactive.consumer.md
@@ -90,7 +90,7 @@ A class to translate the payload.
 **Attributes:**
  
  - <b>`labels`</b>:  The labels of the job. 
- - <b>`job_url`</b>:  The URL of the job. 
+ - <b>`url`</b>:  The URL of the job to check its status. 
 
 
 

--- a/src/github_runner_manager/openstack_cloud/openstack_cloud.py
+++ b/src/github_runner_manager/openstack_cloud/openstack_cloud.py
@@ -148,7 +148,7 @@ class OpenstackCloud:
 
     # Ignore "Too many arguments" as 6 args should be fine. Move to a dataclass if new args are
     # added.
-    def launch_instance(  # pylint: disable=R0913
+    def launch_instance(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self, instance_id: str, image: str, flavor: str, network: str, cloud_init: str
     ) -> OpenstackInstance:
         """Create an OpenStack instance.

--- a/src/github_runner_manager/reactive/consumer.py
+++ b/src/github_runner_manager/reactive/consumer.py
@@ -41,13 +41,13 @@ class JobDetails(BaseModel):
 
     Attributes:
         labels: The labels of the job.
-        job_url: The URL of the job.
+        url: The URL of the job to check its status.
     """
 
     labels: list[str]
-    job_url: HttpUrl
+    url: HttpUrl
 
-    @validator("job_url")
+    @validator("url")
     @classmethod
     def check_job_url_path_is_not_empty(cls, v: HttpUrl) -> HttpUrl:
         """Check that the job_url path is not empty.
@@ -98,11 +98,11 @@ def consume(
                 logger.info(
                     "Received job with labels %s and job_url %s",
                     job_details.labels,
-                    job_details.job_url,
+                    job_details.url,
                 )
                 _spawn_runner(
                     runner_manager=runner_manager,
-                    job_url=job_details.job_url,
+                    job_url=job_details.url,
                     msg=msg,
                     github_client=github_client,
                 )

--- a/src/github_runner_manager/utilities.py
+++ b/src/github_runner_manager/utilities.py
@@ -22,7 +22,7 @@ ReturnT = TypeVar("ReturnT")
 
 
 # This decorator has default arguments, one extra argument is not a problem.
-def retry(  # pylint: disable=too-many-arguments
+def retry(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     exception: Type[Exception] = Exception,
     tries: int = 1,
     delay: float = 0,

--- a/tests/unit/reactive/test_consumer.py
+++ b/tests/unit/reactive/test_consumer.py
@@ -43,7 +43,7 @@ def test_consume(monkeypatch: pytest.MonkeyPatch, queue_config: QueueConfig):
     """
     job_details = consumer.JobDetails(
         labels=[secrets.token_hex(16), secrets.token_hex(16)],
-        job_url=FAKE_JOB_URL,
+        url=FAKE_JOB_URL,
     )
     _put_in_queue(job_details.json(), queue_config.queue_name)
 
@@ -77,7 +77,7 @@ def test_consume_reject_if_job_gets_not_picked_up(
     """
     job_details = consumer.JobDetails(
         labels=[secrets.token_hex(16), secrets.token_hex(16)],
-        job_url=FAKE_JOB_URL,
+        url=FAKE_JOB_URL,
     )
     _put_in_queue(job_details.json(), queue_config.queue_name)
 
@@ -100,15 +100,15 @@ def test_consume_reject_if_job_gets_not_picked_up(
     "job_str",
     [
         pytest.param(
-            '{"labels": ["label1", "label2"], "status": "completed"}', id="job_url missing"
+            '{"labels": ["label1", "label2"], "status": "completed"}', id="job url missing"
         ),
         pytest.param(
-            '{"status": "completed", "job_url": "https://example.com/path"}', id="labels missing"
+            '{"status": "completed", "url": "https://example.com/path"}', id="labels missing"
         ),
         pytest.param(
             '{"labels": ["label1", "label2"], "status": "completed", '
-            '"job_url": "https://example.com"}',
-            id="job_url without path",
+            '"url": "https://example.com"}',
+            id="job url without path",
         ),
         pytest.param("no json at all", id="invalid json"),
     ],


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Use `url` instead of `job_url` in JobDetails.

### Rationale

The webhook router forwards messages containing the key "url", not "job_url" (see also https://github.com/canonical/github-runner-webhook-router/pull/24), meaning parsing will fail with 

```
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-openstack-stg-reactive-ps6-0/charm/venv/github_runner_manager/reactive/consumer.py", line 54, in consume
    job_details = cast(JobDetails, JobDetails.parse_raw(msg.payload))
  File "/var/lib/juju/agents/unit-openstack-stg-reactive-ps6-0/charm/venv/pydantic/main.py", line 549, in parse_raw
    return cls.parse_obj(obj)
  File "/var/lib/juju/agents/unit-openstack-stg-reactive-ps6-0/charm/venv/pydantic/main.py", line 526, in parse_obj
    return cls(**obj)
  File "/var/lib/juju/agents/unit-openstack-stg-reactive-ps6-0/charm/venv/pydantic/main.py", line 341, in __init__
    raise validation_error
pydantic.error_wrappers.ValidationError: 1 validation error for JobDetails
run_url
  field required (type=value_error.missing)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/var/lib/juju/agents/unit-openstack-stg-reactive-ps6-0/charm/venv/github_runner_manager/reactive/runner.py", line 50, in <module>
    main()
  File "/var/lib/juju/agents/unit-openstack-stg-reactive-ps6-0/charm/venv/github_runner_manager/reactive/runner.py", line 46, in main
    consume(mq_uri, queue_name)
  File "/var/lib/juju/agents/unit-openstack-stg-reactive-ps6-0/charm/venv/github_runner_manager/reactive/consumer.py", line 57, in consume
    raise JobError(f"Invalid job details: {msg.payload}") from exc
github_runner_manager.reactive.consumer.JobError: Invalid job details: {"labels":["self-hosted","linux","arm64"],"status":"queued","url":"https://api.github.com/repos/canonical/cbartz-runner-testing/actions/jobs/30432432004"}
```

### Module Changes

`github_runner_manager.reactive.consumer`: Change job_url to url in JobDetails .

### Library/Dependency Changes

n/a

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The library version in `pyproject.toml` is incremented

<!-- Explanation for any unchecked items above -->
