### PR TITLE
fix: revert kill commands to original

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "github-runner-manager"
-version = "0.2.1"
+version = "0.2.2"
 authors = [
     { name = "Canonical IS DevOps", email = "is-devops-team@canonical.com" },
 ]

--- a/src/github_runner_manager/openstack_cloud/openstack_runner_manager.py
+++ b/src/github_runner_manager/openstack_cloud/openstack_runner_manager.py
@@ -582,10 +582,8 @@ class OpenStackRunnerManager(CloudRunnerManager):
             # kill both Runner.Listener and Runner.Worker processes.
             # This kills pre-job.sh, a child process of Runner.Worker.
             kill_command = (
-                f"pgrep -x {RUNNER_LISTENER_PROCESS} "
-                f"&& kill $(pgrep -x {RUNNER_LISTENER_PROCESS});"
-                f"pgrep -x {RUNNER_WORKER_PROCESS} "
-                f"&& kill $(pgrep -x {RUNNER_WORKER_PROCESS});"
+                f"pgrep -x {RUNNER_LISTENER_PROCESS} && kill $(pgrep -x {RUNNER_LISTENER_PROCESS});"
+                f"pgrep -x {RUNNER_WORKER_PROCESS} && kill $(pgrep -x {RUNNER_WORKER_PROCESS});"
             )
         else:
             logger.info(
@@ -593,7 +591,7 @@ class OpenStackRunnerManager(CloudRunnerManager):
             )
             # Only kill Runner.Listener if Runner.Worker does not exist.
             kill_command = (
-                f"pgrep -x {RUNNER_WORKER_PROCESS} || pgrep -x {RUNNER_LISTENER_PROCESS} && "
+                f"! pgrep -x {RUNNER_WORKER_PROCESS} && pgrep -x {RUNNER_LISTENER_PROCESS} && "
                 f"kill $(pgrep -x {RUNNER_LISTENER_PROCESS})"
             )
         # Checking the result of kill command is not useful, as the exit code does not reveal much.

--- a/src/github_runner_manager/openstack_cloud/openstack_runner_manager.py
+++ b/src/github_runner_manager/openstack_cloud/openstack_runner_manager.py
@@ -582,7 +582,8 @@ class OpenStackRunnerManager(CloudRunnerManager):
             # kill both Runner.Listener and Runner.Worker processes.
             # This kills pre-job.sh, a child process of Runner.Worker.
             kill_command = (
-                f"pgrep -x {RUNNER_LISTENER_PROCESS} && kill $(pgrep -x {RUNNER_LISTENER_PROCESS});"
+                f"pgrep -x {RUNNER_LISTENER_PROCESS} && "
+                f"kill $(pgrep -x {RUNNER_LISTENER_PROCESS});"
                 f"pgrep -x {RUNNER_WORKER_PROCESS} && kill $(pgrep -x {RUNNER_WORKER_PROCESS});"
             )
         else:

--- a/src/github_runner_manager/openstack_cloud/openstack_runner_manager.py
+++ b/src/github_runner_manager/openstack_cloud/openstack_runner_manager.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Iterator, Sequence
 
+import fabric
 import invoke
 import jinja2
 import paramiko
@@ -595,8 +596,16 @@ class OpenStackRunnerManager(CloudRunnerManager):
                 f"! pgrep -x {RUNNER_WORKER_PROCESS} && pgrep -x {RUNNER_LISTENER_PROCESS} && "
                 f"kill $(pgrep -x {RUNNER_LISTENER_PROCESS})"
             )
+        logger.info("Running kill process command: %s", kill_command)
         # Checking the result of kill command is not useful, as the exit code does not reveal much.
-        ssh_conn.run(kill_command, warn=True, timeout=30)
+        result: fabric.Result = ssh_conn.run(kill_command, warn=True, timeout=30)
+        logger.info(
+            "Kill process command output, ok: %s code %s, out: %s, err: %s",
+            result.ok,
+            result.return_code,
+            result.stdout,
+            result.stderr,
+        )
 
     @retry(tries=3, delay=5, backoff=2, local_logger=logger)
     def _health_check(self, instance: OpenstackInstance) -> bool:


### PR DESCRIPTION
Applicable spec: N/A

### Overview

- Revert the kill commands to what used to be before the refactor.

### Rationale

These set of commands are heavily tested. The other commands kill the running workers.

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library/Dependency Changes

<!-- Any changes to libraries -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The library version in `pyproject.toml` is incremented

<!-- Explanation for any unchecked items above -->
