### PR TITLE
feat: Reactive reconcile

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "github-runner-manager"
-version = "0.3.1"
+version = "0.3.2"
 authors = [
     { name = "Canonical IS DevOps", email = "is-devops-team@canonical.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "github-runner-manager"
-version = "0.3.0"
+version = "0.3.1"
 authors = [
     { name = "Canonical IS DevOps", email = "is-devops-team@canonical.com" },
 ]

--- a/src-docs/openstack_cloud.openstack_runner_manager.md
+++ b/src-docs/openstack_cloud.openstack_runner_manager.md
@@ -17,7 +17,7 @@ Manager for self-hosted runner on OpenStack.
 
 ---
 
-<a href="../src/github_runner_manager/openstack_cloud/openstack_runner_manager.py#L73"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/openstack_cloud/openstack_runner_manager.py#L74"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `OpenStackCloudConfig`
 Configuration for OpenStack cloud authorisation information. 
@@ -47,7 +47,7 @@ __init__(clouds_config: dict[str, dict], cloud: str) → None
 
 ---
 
-<a href="../src/github_runner_manager/openstack_cloud/openstack_runner_manager.py#L86"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/openstack_cloud/openstack_runner_manager.py#L87"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `OpenStackServerConfig`
 Configuration for OpenStack server. 
@@ -78,7 +78,7 @@ __init__(image: str, flavor: str, network: str) → None
 
 ---
 
-<a href="../src/github_runner_manager/openstack_cloud/openstack_runner_manager.py#L101"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/openstack_cloud/openstack_runner_manager.py#L102"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `OpenStackRunnerManagerConfig`
 Configuration for OpenStack runner manager. 
@@ -119,7 +119,7 @@ __init__(
 
 ---
 
-<a href="../src/github_runner_manager/openstack_cloud/openstack_runner_manager.py#L135"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/openstack_cloud/openstack_runner_manager.py#L136"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `OpenStackRunnerManager`
 Manage self-hosted runner on OpenStack cloud. 
@@ -130,7 +130,7 @@ Manage self-hosted runner on OpenStack cloud.
  
  - <b>`name_prefix`</b>:  The name prefix of the runners created. 
 
-<a href="../src/github_runner_manager/openstack_cloud/openstack_runner_manager.py#L142"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/openstack_cloud/openstack_runner_manager.py#L143"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `__init__`
 
@@ -162,7 +162,7 @@ The prefix of runner names.
 
 ---
 
-<a href="../src/github_runner_manager/openstack_cloud/openstack_runner_manager.py#L354"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/openstack_cloud/openstack_runner_manager.py#L355"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `cleanup`
 
@@ -185,7 +185,7 @@ Cleanup runner and resource on the cloud.
 
 ---
 
-<a href="../src/github_runner_manager/openstack_cloud/openstack_runner_manager.py#L181"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/openstack_cloud/openstack_runner_manager.py#L182"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `create_runner`
 
@@ -215,7 +215,7 @@ Create a self-hosted runner.
 
 ---
 
-<a href="../src/github_runner_manager/openstack_cloud/openstack_runner_manager.py#L289"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/openstack_cloud/openstack_runner_manager.py#L290"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `delete_runner`
 
@@ -239,7 +239,7 @@ Delete self-hosted runners.
 
 ---
 
-<a href="../src/github_runner_manager/openstack_cloud/openstack_runner_manager.py#L323"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/openstack_cloud/openstack_runner_manager.py#L324"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `flush_runners`
 
@@ -262,7 +262,7 @@ Remove idle and/or busy runners.
 
 ---
 
-<a href="../src/github_runner_manager/openstack_cloud/openstack_runner_manager.py#L230"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/openstack_cloud/openstack_runner_manager.py#L231"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `get_runner`
 
@@ -285,7 +285,7 @@ Get a self-hosted runner by instance id.
 
 ---
 
-<a href="../src/github_runner_manager/openstack_cloud/openstack_runner_manager.py#L257"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/openstack_cloud/openstack_runner_manager.py#L258"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `get_runners`
 

--- a/src-docs/reactive.consumer.md
+++ b/src-docs/reactive.consumer.md
@@ -8,7 +8,7 @@ Module responsible for consuming jobs from the message queue.
 
 ---
 
-<a href="../src/github_runner_manager/reactive/consumer.py#L73"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/reactive/consumer.py#L78"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_queue_size`
 
@@ -16,7 +16,7 @@ Module responsible for consuming jobs from the message queue.
 get_queue_size(queue_config: QueueConfig) → int
 ```
 
-Get the size of the queue. 
+Get the size of the message queue. 
 
 
 
@@ -30,9 +30,15 @@ Get the size of the queue.
  The size of the queue. 
 
 
+
+**Raises:**
+ 
+ - <b>`QueueError`</b>:  If an error when communicating with the queue occurs. 
+
+
 ---
 
-<a href="../src/github_runner_manager/reactive/consumer.py#L84"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/reactive/consumer.py#L98"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `consume`
 
@@ -61,11 +67,12 @@ Log the job details and acknowledge the message. If the job details are invalid,
 **Raises:**
  
  - <b>`JobError`</b>:  If the job details are invalid. 
+ - <b>`QueueError`</b>:  If an error when communicating with the queue occurs. 
 
 
 ---
 
-<a href="../reactive/consumer/signal_handler#L181"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../reactive/consumer/signal_handler#L199"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `signal_handler`
 
@@ -86,7 +93,7 @@ The signal handler exits the process.
 
 ---
 
-<a href="../src/github_runner_manager/reactive/consumer.py#L27"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/reactive/consumer.py#L28"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `JobPickedUpStates`
 The states of a job that indicate it has been picked up. 
@@ -104,7 +111,7 @@ The states of a job that indicate it has been picked up.
 
 ---
 
-<a href="../src/github_runner_manager/reactive/consumer.py#L39"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/reactive/consumer.py#L40"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `JobDetails`
 A class to translate the payload. 
@@ -121,7 +128,7 @@ A class to translate the payload.
 
 ---
 
-<a href="../src/github_runner_manager/reactive/consumer.py#L50"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/reactive/consumer.py#L51"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `check_job_url_path_is_not_empty`
 
@@ -151,10 +158,21 @@ Check that the job_url path is not empty.
 
 ---
 
-<a href="../src/github_runner_manager/reactive/consumer.py#L69"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/reactive/consumer.py#L70"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `JobError`
 Raised when a job error occurs. 
+
+
+
+
+
+---
+
+<a href="../src/github_runner_manager/reactive/consumer.py#L74"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `QueueError`
+Raised when an error when communicating with the queue occurs. 
 
 
 

--- a/src-docs/reactive.consumer.md
+++ b/src-docs/reactive.consumer.md
@@ -74,7 +74,7 @@ Log the job details and acknowledge the message. If the job details are invalid,
 
 ---
 
-<a href="../reactive/consumer/signal_handler#L229"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../reactive/consumer/signal_handler#L234"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `signal_handler`
 

--- a/src-docs/reactive.consumer.md
+++ b/src-docs/reactive.consumer.md
@@ -74,7 +74,7 @@ Log the job details and acknowledge the message. If the job details are invalid,
 
 ---
 
-<a href="../reactive/consumer/signal_handler#L230"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../reactive/consumer/signal_handler#L229"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `signal_handler`
 

--- a/src-docs/reactive.consumer.md
+++ b/src-docs/reactive.consumer.md
@@ -10,6 +10,30 @@ Module responsible for consuming jobs from the message queue.
 
 <a href="../src/github_runner_manager/reactive/consumer.py#L73"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
+## <kbd>function</kbd> `get_queue_size`
+
+```python
+get_queue_size(queue_config: QueueConfig) → int
+```
+
+Get the size of the queue. 
+
+
+
+**Args:**
+ 
+ - <b>`queue_config`</b>:  The configuration for the message queue. 
+
+
+
+**Returns:**
+ The size of the queue. 
+
+
+---
+
+<a href="../src/github_runner_manager/reactive/consumer.py#L84"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
 ## <kbd>function</kbd> `consume`
 
 ```python
@@ -41,7 +65,7 @@ Log the job details and acknowledge the message. If the job details are invalid,
 
 ---
 
-<a href="../reactive/consumer/signal_handler#L170"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../reactive/consumer/signal_handler#L181"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `signal_handler`
 

--- a/src-docs/reactive.process_manager.md
+++ b/src-docs/reactive.process_manager.md
@@ -1,0 +1,55 @@
+<!-- markdownlint-disable -->
+
+<a href="../src/github_runner_manager/reactive/process_manager.py#L0"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+# <kbd>module</kbd> `reactive.process_manager`
+Module for managing processes which spawn runners reactively. 
+
+**Global Variables**
+---------------
+- **PYTHON_BIN**
+- **REACTIVE_RUNNER_SCRIPT_MODULE**
+- **REACTIVE_RUNNER_CMD_LINE_PREFIX**
+- **PID_CMD_COLUMN_WIDTH**
+- **PIDS_COMMAND_LINE**
+- **UBUNTU_USER**
+- **RUNNER_CONFIG_ENV_VAR**
+
+---
+
+<a href="../src/github_runner_manager/reactive/process_manager.py#L40"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>function</kbd> `reconcile`
+
+```python
+reconcile(quantity: int, runner_config: RunnerConfig) → int
+```
+
+Reconcile the number of reactive runner processes. 
+
+
+
+**Args:**
+ 
+ - <b>`quantity`</b>:  The number of processes to spawn. 
+ - <b>`runner_config`</b>:  The reactive runner configuration. 
+
+Raises a ReactiveRunnerError if the runner fails to spawn. 
+
+
+
+**Returns:**
+ The number of reactive runner processes spawned/killed. 
+
+
+---
+
+<a href="../src/github_runner_manager/reactive/process_manager.py#L36"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `ReactiveRunnerError`
+Raised when a reactive runner error occurs. 
+
+
+
+
+

--- a/src-docs/reactive.runner_manager.md
+++ b/src-docs/reactive.runner_manager.md
@@ -8,7 +8,7 @@ Module for reconciling amount of runner and reactive runner processes.
 
 ---
 
-<a href="../src/github_runner_manager/reactive/runner_manager.py#L15"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/reactive/runner_manager.py#L16"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `reconcile`
 

--- a/src-docs/reactive.runner_manager.md
+++ b/src-docs/reactive.runner_manager.md
@@ -14,7 +14,7 @@ Module for reconciling amount of runner and reactive runner processes.
 
 ```python
 reconcile(
-    quantity: int,
+    expected_quantity: int,
     runner_manager: RunnerManager,
     runner_config: RunnerConfig
 ) → int
@@ -22,7 +22,7 @@ reconcile(
 
 Reconcile runners reactively. 
 
-The reconciliation attempts to make the following equation true:  quantity_of_current_runners + reactive_processes_consuming_jobs == quantity. 
+The reconciliation attempts to make the following equation true:  quantity_of_current_runners + amount_of_reactive_processes_consuming_jobs  == expected_quantity 
 
 A few examples: 
 
@@ -44,7 +44,7 @@ In addition to this behaviour, reconciliation also checks the queue at the start
 
 **Args:**
  
- - <b>`quantity`</b>:  Number of intended amount of runners + reactive processes. 
+ - <b>`expected_quantity`</b>:  Number of intended amount of runners + reactive processes. 
  - <b>`runner_manager`</b>:  The runner manager to interact with current running runners. 
  - <b>`runner_config`</b>:  The reactive runner config. 
 

--- a/src-docs/reactive.runner_manager.md
+++ b/src-docs/reactive.runner_manager.md
@@ -3,53 +3,54 @@
 <a href="../src/github_runner_manager/reactive/runner_manager.py#L0"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 # <kbd>module</kbd> `reactive.runner_manager`
-Module for managing reactive runners. 
+Module for reconciling amount of runner and reactive runner processes. 
 
-**Global Variables**
----------------
-- **PYTHON_BIN**
-- **REACTIVE_RUNNER_SCRIPT_MODULE**
-- **REACTIVE_RUNNER_CMD_LINE_PREFIX**
-- **PID_CMD_COLUMN_WIDTH**
-- **PIDS_COMMAND_LINE**
-- **UBUNTU_USER**
-- **RUNNER_CONFIG_ENV_VAR**
 
 ---
 
-<a href="../src/github_runner_manager/reactive/runner_manager.py#L40"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/reactive/runner_manager.py#L14"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `reconcile`
 
 ```python
-reconcile(quantity: int, runner_config: RunnerConfig) → int
+reconcile(
+    quantity: int,
+    runner_manager: RunnerManager,
+    runner_config: RunnerConfig
+) → int
 ```
 
-Spawn a runner reactively. 
+Reconcile runners reactively. 
+
+The reconciliation attempts to make the following equation true:  quantity_of_current_runners + reactive_processes_consuming_jobs == quantity. 
+
+A few examples: 
+
+1. If there are 5 runners and 5 reactive processes and the quantity is 10,  no action is taken. 2. If there are 5 runners and 5 reactive processes and the quantity is 15,  5 reactive processes are created. 3. If there are 5 runners and 5 reactive processes and quantity is 7,  3 reactive processes are killed. 4. If there are 5 runners and 5 reactive processes and quantity is 5,  all reactive processes are killed. 5. If there are 5 runners and 5 reactive processes and quantity is 4,  1 runner is killed and all reactive processes are killed. 
+
+
+
+So if the quantity is equal to the sum of the current runners and reactive processes, no action is taken, 
+
+If the quantity is greater than the sum of the current runners and reactive processes, additional reactive processes are created. 
+
+If the quantity is greater than or equal to the quantity of the current runners, but less than the sum of the current runners and reactive processes, additional reactive processes will be killed. 
+
+If the quantity is less than the sum of the current runners, additional runners are killed and all reactive processes are killed. 
+
+In addition to this behaviour, reconciliation also checks the queue at the start and removes all idle runners if the queue is empty, to ensure that no idle runners are left behind if there are no new jobs. 
 
 
 
 **Args:**
  
- - <b>`quantity`</b>:  The number of runners to spawn. 
- - <b>`runner_config`</b>:  The reactive runner configuration. 
-
-Raises a ReactiveRunnerError if the runner fails to spawn. 
+ - <b>`quantity`</b>:  Number of intended amount of runners + reactive processes. 
+ - <b>`runner_manager`</b>:  The runner manager to interact with current running runners. 
+ - <b>`runner_config`</b>:  The reactive runner config. 
 
 
 
 **Returns:**
- The number of reactive runner processes spawned. 
-
-
----
-
-<a href="../src/github_runner_manager/reactive/runner_manager.py#L36"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
-
-## <kbd>class</kbd> `ReactiveRunnerError`
-Raised when a reactive runner error occurs. 
-
-
-
+ The number of reactive processes created. If negative, its absolute value is equal to the number of processes killed. 
 
 

--- a/src-docs/reactive.runner_manager.md
+++ b/src-docs/reactive.runner_manager.md
@@ -8,7 +8,7 @@ Module for reconciling amount of runner and reactive runner processes.
 
 ---
 
-<a href="../src/github_runner_manager/reactive/runner_manager.py#L14"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/reactive/runner_manager.py#L15"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `reconcile`
 

--- a/src/github_runner_manager/manager/runner_scaler.py
+++ b/src/github_runner_manager/manager/runner_scaler.py
@@ -252,12 +252,46 @@ class RunnerScaler:
     def _reconcile_reactive(self, quantity: int) -> int:
         """Reconcile runners reactively.
 
+        The reconciliation attempts to make the following equation true:
+            quantity_of_current_runners + reactive_processes_consuming_jobs == quantity.
+
+        A few examples:
+
+        1. If there are 5 runners and 5 reactive processes and the quantity is 10,
+            no action is taken.
+        2. If there are 5 runners and 5 reactive processes and the quantity is 15,
+            5 reactive processes are created.
+        3. If there are 5 runners and 5 reactive processes and quantity is 7,
+            3 reactive processes are killed.
+        4. If there are 5 runners and 5 reactive processes and quantity is 5,
+            all reactive processes are killed.
+        5. If there are 5 runners and 5 reactive processes and quantity is 4,
+            1 runner is killed and all reactive processes are killed.
+
+
+        So if the quantity is equal to the sum of the current runners and reactive processes,
+        no action is taken,
+
+        If the quantity is greater than the sum of the current
+        runners and reactive processes, additional reactive processes are created.
+
+        If the quantity is greater than or equal to the quantity of the current runners,
+        but less than the sum of the current runners and reactive processes,
+        additional reactive processes will be killed.
+
+        If the quantity is less than the sum of the current runners,
+        additional runners are killed and all reactive processes are killed.
+
+        In addition to this behaviour, reconciliation also checks the queue at the start and
+        removes all idle runners if the queue is empty, to ensure that
+        no idle runners are left behind if there are no new jobs.
+
         Args:
-            quantity: Number of intended runners.
+            quantity: Number of intended amount of runners + reactive processes.
 
         Returns:
-            The difference between intended runners and actual runners. In reactive mode
-            this number is never negative as additional processes should terminate after a timeout.
+            The number of reactive processes created. If negative, its absolute value is equal
+            to the number of processes killed.
         """
         logger.info("Reactive mode is experimental and not yet fully implemented.")
         self._manager.cleanup()

--- a/src/github_runner_manager/manager/runner_scaler.py
+++ b/src/github_runner_manager/manager/runner_scaler.py
@@ -127,7 +127,7 @@ class RunnerScaler:
         if self._reactive_config is not None:
             logger.info("Reactive configuration detected, going into experimental reactive mode.")
             return reactive_runner_manager.reconcile(
-                quantity=quantity,
+                expected_quantity=quantity,
                 runner_manager=self._manager,
                 runner_config=self._reactive_config,
             )

--- a/src/github_runner_manager/reactive/consumer.py
+++ b/src/github_runner_manager/reactive/consumer.py
@@ -120,39 +120,41 @@ def consume(
         QueueError: If an error when communicating with the queue occurs.
     """
     try:
-with Connection(queue_config.mongodb_uri) as conn, closing(SimpleQueue(conn, queue_config.queue_name)) as simple_queue, with signal_handler(signal.SIGTERM):
-                    msg = simple_queue.get(block=True)
-                    try:
-                        job_details = cast(JobDetails, JobDetails.parse_raw(msg.payload))
-                    except ValidationError as exc:
-                        logger.error("Found invalid job details, will reject the message.")
-                        msg.reject(requeue=False)
-                        raise JobError(f"Invalid job details: {msg.payload}") from exc
-                    logger.info(
-                        "Received job with labels %s and job_url %s",
-                        job_details.labels,
-                        job_details.url,
-                    )
-                    if not _validate_labels(
-                        labels=job_details.labels, supported_labels=supported_labels
-                    ):
-                        logger.error(
-                            "Found unsupported job labels in %s. "
-                            "Will not spawn a runner and reject the message.",
-                            job_details.labels,
-                        )
-                        # We currently do not expect this to happen, but we should handle it.
-                        # We do not want to requeue the message as it will be rejected again.
-                        # This may change in the future when messages for multiple
-                        # flavours are sent to the same queue.
-                        msg.reject(requeue=False)
-                    else:
-                        _spawn_runner(
-                            runner_manager=runner_manager,
-                            job_url=job_details.url,
-                            msg=msg,
-                            github_client=github_client,
-                        )
+        with (
+            Connection(queue_config.mongodb_uri) as conn,
+            closing(SimpleQueue(conn, queue_config.queue_name)) as simple_queue,
+            signal_handler(signal.SIGTERM),
+        ):
+            msg = simple_queue.get(block=True)
+            try:
+                job_details = cast(JobDetails, JobDetails.parse_raw(msg.payload))
+            except ValidationError as exc:
+                logger.error("Found invalid job details, will reject the message.")
+                msg.reject(requeue=False)
+                raise JobError(f"Invalid job details: {msg.payload}") from exc
+            logger.info(
+                "Received job with labels %s and job_url %s",
+                job_details.labels,
+                job_details.url,
+            )
+            if not _validate_labels(labels=job_details.labels, supported_labels=supported_labels):
+                logger.error(
+                    "Found unsupported job labels in %s. "
+                    "Will not spawn a runner and reject the message.",
+                    job_details.labels,
+                )
+                # We currently do not expect this to happen, but we should handle it.
+                # We do not want to requeue the message as it will be rejected again.
+                # This may change in the future when messages for multiple
+                # flavours are sent to the same queue.
+                msg.reject(requeue=False)
+            else:
+                _spawn_runner(
+                    runner_manager=runner_manager,
+                    job_url=job_details.url,
+                    msg=msg,
+                    github_client=github_client,
+                )
     except KombuError as exc:
         raise QueueError("Error when communicating with the queue") from exc
 

--- a/src/github_runner_manager/reactive/consumer.py
+++ b/src/github_runner_manager/reactive/consumer.py
@@ -154,7 +154,6 @@ def consume(
         raise QueueError("Error when communicating with the queue") from exc
 
 
-
 def _validate_labels(labels: Labels, supported_labels: Labels) -> bool:
     """Validate the labels of the job.
 

--- a/src/github_runner_manager/reactive/consumer.py
+++ b/src/github_runner_manager/reactive/consumer.py
@@ -70,6 +70,17 @@ class JobError(Exception):
     """Raised when a job error occurs."""
 
 
+def get_queue_size(queue_config: QueueConfig) -> int:
+    """Get the size of the queue.
+
+    Args:
+        queue_config: The configuration for the message queue.
+
+    Returns:
+        The size of the queue.
+    """
+
+
 def consume(
     queue_config: QueueConfig, runner_manager: RunnerManager, github_client: GithubClient
 ) -> None:

--- a/src/github_runner_manager/reactive/consumer.py
+++ b/src/github_runner_manager/reactive/consumer.py
@@ -120,9 +120,7 @@ def consume(
         QueueError: If an error when communicating with the queue occurs.
     """
     try:
-        with Connection(queue_config.mongodb_uri) as conn:
-            with closing(SimpleQueue(conn, queue_config.queue_name)) as simple_queue:
-                with signal_handler(signal.SIGTERM):
+with Connection(queue_config.mongodb_uri) as conn, closing(SimpleQueue(conn, queue_config.queue_name)) as simple_queue, with signal_handler(signal.SIGTERM):
                     msg = simple_queue.get(block=True)
                     try:
                         job_details = cast(JobDetails, JobDetails.parse_raw(msg.payload))

--- a/src/github_runner_manager/reactive/process_manager.py
+++ b/src/github_runner_manager/reactive/process_manager.py
@@ -90,6 +90,15 @@ def _get_pids() -> list[int]:
     if result.returncode != 0:
         raise ReactiveRunnerError("Failed to get list of processes")
 
+    # stdout will look like
+    #
+    # ps axo cmd:57,pid --no-headers --sort=-start_time         2302635
+    # -bash                                                     2302498
+    # /bin/sh -c /usr/bin/python3 -m github_runner_manager.reac 1757306
+    # /usr/bin/python3 -m github_runner_manager.reactive.runner 1757308
+
+    # we filter for the command line of the reactive runner processes and extract the PID
+
     return [
         int(line.rstrip().rsplit(maxsplit=1)[-1])
         for line in result.stdout.decode().split("\n")

--- a/src/github_runner_manager/reactive/process_manager.py
+++ b/src/github_runner_manager/reactive/process_manager.py
@@ -1,0 +1,140 @@
+#  Copyright 2024 Canonical Ltd.
+#  See LICENSE file for licensing details.
+
+"""Module for managing processes which spawn runners reactively."""
+import logging
+import os
+import shutil
+import signal
+
+# All commands run by subprocess are secure.
+import subprocess  # nosec
+from pathlib import Path
+
+from github_runner_manager.reactive.types_ import RunnerConfig
+from github_runner_manager.utilities import secure_run_subprocess
+
+logger = logging.getLogger(__name__)
+
+REACTIVE_RUNNER_LOG_DIR = Path("/var/log/reactive_runner")
+
+PYTHON_BIN = "/usr/bin/python3"
+REACTIVE_RUNNER_SCRIPT_MODULE = "github_runner_manager.reactive.runner"
+REACTIVE_RUNNER_CMD_LINE_PREFIX = f"{PYTHON_BIN} -m {REACTIVE_RUNNER_SCRIPT_MODULE}"
+PID_CMD_COLUMN_WIDTH = len(REACTIVE_RUNNER_CMD_LINE_PREFIX)
+PIDS_COMMAND_LINE = [
+    "ps",
+    "axo",
+    f"cmd:{PID_CMD_COLUMN_WIDTH},pid",
+    "--no-headers",
+    "--sort=-start_time",
+]
+UBUNTU_USER = "ubuntu"
+RUNNER_CONFIG_ENV_VAR = "RUNNER_CONFIG"
+
+
+class ReactiveRunnerError(Exception):
+    """Raised when a reactive runner error occurs."""
+
+
+def reconcile(quantity: int, runner_config: RunnerConfig) -> int:
+    """Reconcile the number of reactive runner processes.
+
+    Args:
+        quantity: The number of processes to spawn.
+        runner_config: The reactive runner configuration.
+
+    Raises a ReactiveRunnerError if the runner fails to spawn.
+
+    Returns:
+        The number of reactive runner processes spawned/killed.
+    """
+    pids = _get_pids()
+    current_quantity = len(pids)
+    logger.info("Current quantity of reactive runner processes: %s", current_quantity)
+    delta = quantity - current_quantity
+    if delta > 0:
+        logger.info("Will spawn %d new reactive runner process(es)", delta)
+        _setup_logging_for_processes()
+        for _ in range(delta):
+            _spawn_runner(runner_config)
+    elif delta < 0:
+        logger.info("Will kill %d process(es).", -delta)
+        for pid in pids[:-delta]:
+            logger.info("Killing reactive runner process with pid %s", pid)
+            try:
+                os.kill(pid, signal.SIGTERM)
+            except ProcessLookupError:
+                # There can be a race condition that the process has already terminated.
+                # We just ignore and log the fact.
+                logger.info(
+                    "Failed to kill process with pid %s. Process might have terminated it self.",
+                    pid,
+                )
+    else:
+        logger.info("No changes to number of reactive runner processes needed.")
+
+    return delta
+
+
+def _get_pids() -> list[int]:
+    """Get the PIDs of the reactive runners processes.
+
+    Returns:
+        The PIDs of the reactive runner processes sorted by start time in descending order.
+
+    Raises:
+        ReactiveRunnerError: If the command to get the PIDs fails
+    """
+    result = secure_run_subprocess(cmd=PIDS_COMMAND_LINE)
+    if result.returncode != 0:
+        raise ReactiveRunnerError("Failed to get list of processes")
+
+    return [
+        int(line.rstrip().rsplit(maxsplit=1)[-1])
+        for line in result.stdout.decode().split("\n")
+        if line.startswith(REACTIVE_RUNNER_CMD_LINE_PREFIX)
+    ]
+
+
+def _setup_logging_for_processes() -> None:
+    """Set up the log dir."""
+    if not REACTIVE_RUNNER_LOG_DIR.exists():
+        REACTIVE_RUNNER_LOG_DIR.mkdir()
+        shutil.chown(REACTIVE_RUNNER_LOG_DIR, user=UBUNTU_USER, group=UBUNTU_USER)
+
+
+def _spawn_runner(runner_config: RunnerConfig) -> None:
+    """Spawn a runner.
+
+    Args:
+        runner_config: The runner configuration to pass to the spawned runner process.
+    """
+    env = {
+        "PYTHONPATH": os.environ["PYTHONPATH"],
+        RUNNER_CONFIG_ENV_VAR: runner_config.json(),
+    }
+    # We do not want to wait for the process to finish, so we do not use with statement.
+    # We trust the command.
+    command = " ".join(
+        [
+            PYTHON_BIN,
+            "-m",
+            REACTIVE_RUNNER_SCRIPT_MODULE,
+            ">>",
+            # $$ will be replaced by the PID of the process, so we can track the error log easily.
+            f"{REACTIVE_RUNNER_LOG_DIR}/$$.log",
+            "2>&1",
+        ]
+    )
+    logger.debug("Spawning a new reactive runner process with command: %s", command)
+    process = subprocess.Popen(  # pylint: disable=consider-using-with  # nosec
+        command,
+        shell=True,
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        user=UBUNTU_USER,
+    )
+
+    logger.info("Spawned a new reactive runner process with pid %s", process.pid)

--- a/src/github_runner_manager/reactive/runner.py
+++ b/src/github_runner_manager/reactive/runner.py
@@ -11,7 +11,7 @@ from github_runner_manager.github_client import GithubClient
 from github_runner_manager.manager.runner_manager import RunnerManager
 from github_runner_manager.openstack_cloud.openstack_runner_manager import OpenStackRunnerManager
 from github_runner_manager.reactive.consumer import consume
-from github_runner_manager.reactive.runner_manager import RUNNER_CONFIG_ENV_VAR
+from github_runner_manager.reactive.process_manager import RUNNER_CONFIG_ENV_VAR
 from github_runner_manager.reactive.types_ import RunnerConfig
 
 

--- a/src/github_runner_manager/reactive/runner_manager.py
+++ b/src/github_runner_manager/reactive/runner_manager.py
@@ -66,7 +66,7 @@ def reconcile(
     if get_queue_size(runner_config.queue) == 0:
         runner_manager.flush_runners(FlushMode.FLUSH_IDLE)
 
-    # Only respect runners which are online on GitHub to prevent machines to be just in
+    # Only count runners which are online on GitHub to prevent machines to be just in
     # construction to be counted and then killed immediately by the process manager.
     runners = runner_manager.get_runners(
         github_states=[GitHubRunnerState.IDLE, GitHubRunnerState.BUSY]

--- a/src/github_runner_manager/reactive/runner_manager.py
+++ b/src/github_runner_manager/reactive/runner_manager.py
@@ -61,7 +61,17 @@ def reconcile(quantity: int, runner_manager: RunnerManager, runner_config: Runne
     runner_manager.cleanup()
     if get_queue_size(runner_config.queue) == 0:
         runner_manager.flush_runners(FlushMode.FLUSH_IDLE)
+
+    runners = runner_manager.get_runners()
+    runner_diff = quantity - len(runners)
+
+    if runner_diff >= 0:
+        process_quantity = runner_diff
+    else:
+        runner_manager.delete_runners(-runner_diff)
+        process_quantity = 0
+
     return process_manager.reconcile(
-        quantity=quantity,
+        quantity=process_quantity,
         runner_config=runner_config,
     )

--- a/src/github_runner_manager/reactive/runner_manager.py
+++ b/src/github_runner_manager/reactive/runner_manager.py
@@ -4,8 +4,9 @@
 """Module for reconciling amount of runner and reactive runner processes."""
 import logging
 
-from github_runner_manager.manager.runner_manager import RunnerManager
+from github_runner_manager.manager.runner_manager import FlushMode, RunnerManager
 from github_runner_manager.reactive import process_manager
+from github_runner_manager.reactive.consumer import get_queue_size
 from github_runner_manager.reactive.types_ import RunnerConfig
 
 logger = logging.getLogger(__name__)
@@ -58,6 +59,8 @@ def reconcile(quantity: int, runner_manager: RunnerManager, runner_config: Runne
         to the number of processes killed.
     """
     runner_manager.cleanup()
+    if get_queue_size(runner_config.queue) == 0:
+        runner_manager.flush_runners(FlushMode.FLUSH_IDLE)
     return process_manager.reconcile(
         quantity=quantity,
         runner_config=runner_config,

--- a/src/github_runner_manager/reactive/runner_manager.py
+++ b/src/github_runner_manager/reactive/runner_manager.py
@@ -12,11 +12,14 @@ from github_runner_manager.reactive.types_ import RunnerConfig
 logger = logging.getLogger(__name__)
 
 
-def reconcile(quantity: int, runner_manager: RunnerManager, runner_config: RunnerConfig) -> int:
+def reconcile(
+    expected_quantity: int, runner_manager: RunnerManager, runner_config: RunnerConfig
+) -> int:
     """Reconcile runners reactively.
 
     The reconciliation attempts to make the following equation true:
-        quantity_of_current_runners + reactive_processes_consuming_jobs == quantity.
+        quantity_of_current_runners + amount_of_reactive_processes_consuming_jobs
+            == expected_quantity
 
     A few examples:
 
@@ -50,7 +53,7 @@ def reconcile(quantity: int, runner_manager: RunnerManager, runner_config: Runne
     no idle runners are left behind if there are no new jobs.
 
     Args:
-        quantity: Number of intended amount of runners + reactive processes.
+        expected_quantity: Number of intended amount of runners + reactive processes.
         runner_manager: The runner manager to interact with current running runners.
         runner_config: The reactive runner config.
 
@@ -63,7 +66,7 @@ def reconcile(quantity: int, runner_manager: RunnerManager, runner_config: Runne
         runner_manager.flush_runners(FlushMode.FLUSH_IDLE)
 
     runners = runner_manager.get_runners()
-    runner_diff = quantity - len(runners)
+    runner_diff = expected_quantity - len(runners)
 
     if runner_diff >= 0:
         process_quantity = runner_diff

--- a/tests/unit/reactive/test_consumer.py
+++ b/tests/unit/reactive/test_consumer.py
@@ -4,7 +4,6 @@
 import secrets
 from contextlib import closing
 from datetime import datetime, timezone
-from queue import Empty
 from random import randint
 from unittest.mock import MagicMock
 
@@ -49,7 +48,7 @@ def test_consume(labels: Labels, supported_labels: Labels, queue_config: QueueCo
     """
     arrange: A job with valid labels placed in the message queue which has not yet been picked up.
     act: Call consume.
-    assert: A runner is created and the message is acknowledged.
+    assert: A runner is created and the message is removed from the queue.
     """
     job_details = consumer.JobDetails(
         labels=labels,
@@ -73,9 +72,7 @@ def test_consume(labels: Labels, supported_labels: Labels, queue_config: QueueCo
 
     runner_manager_mock.create_runners.assert_called_once_with(1)
 
-    # Ensure message has been acknowledged by assuming an Empty exception is raised
-    with pytest.raises(Empty):
-        _consume_from_queue(queue_config.queue_name)
+    _assert_queue_is_empty(queue_config.queue_name)
 
 
 def test_consume_reject_if_job_gets_not_picked_up(queue_config: QueueConfig):
@@ -178,7 +175,7 @@ def test_job_details_validation_error(job_str: str, queue_config: QueueConfig):
     """
     arrange: A job placed in the message queue with invalid details.
     act: Call consume
-    assert: A JobError is raised and the message is requeued.
+    assert: A JobError is raised and the message is not requeued.
     """
     queue_name = queue_config.queue_name
     _put_in_queue(job_str, queue_name)
@@ -196,9 +193,7 @@ def test_job_details_validation_error(job_str: str, queue_config: QueueConfig):
         )
     assert "Invalid job details" in str(exc_info.value)
 
-    # Ensure message has been requeued by reconsuming it
-    msg = _consume_from_queue(queue_name)
-    assert msg.payload == job_str
+    _assert_queue_is_empty(queue_config.queue_name)
 
 
 @pytest.mark.parametrize(
@@ -217,7 +212,7 @@ def test_consume_reject_if_labels_not_supported(
     """
     arrange: A job placed in the message queue with unsupported labels.
     act: Call consume.
-    assert: The message is requeued.
+    assert: No runner is spawned and the message is removed from the queue.
     """
     job_details = consumer.JobDetails(
         labels=labels,
@@ -239,9 +234,8 @@ def test_consume_reject_if_labels_not_supported(
         supported_labels=supported_labels,
     )
 
-    # Ensure message has been requeued by reconsuming it
-    msg = _consume_from_queue(queue_config.queue_name)
-    assert msg.payload == job_details.json()
+    runner_manager_mock.create_runners.assert_not_called()
+    _assert_queue_is_empty(queue_config.queue_name)
 
 
 def _create_job_info(status: JobStatus) -> JobInfo:
@@ -286,3 +280,14 @@ def _consume_from_queue(queue_name: str) -> Message:
     with Connection(IN_MEMORY_URI) as conn:
         with closing(conn.SimpleQueue(queue_name)) as simple_queue:
             return simple_queue.get(block=False)
+
+
+def _assert_queue_is_empty(queue_name: str) -> None:
+    """Assert that the queue is empty.
+
+    Args:
+        queue_name: The name of the queue.
+    """
+    with Connection(IN_MEMORY_URI) as conn:
+        with closing(conn.SimpleQueue(queue_name)) as simple_queue:
+            assert simple_queue.qsize() == 0

--- a/tests/unit/reactive/test_consumer.py
+++ b/tests/unit/reactive/test_consumer.py
@@ -13,7 +13,7 @@ from kombu import Connection, Message
 from kombu.exceptions import KombuError
 
 from github_runner_manager.reactive import consumer
-from github_runner_manager.reactive.consumer import JobError, get_queue_size, Labels
+from github_runner_manager.reactive.consumer import JobError, Labels, get_queue_size
 from github_runner_manager.reactive.types_ import QueueConfig
 from github_runner_manager.types_.github import JobConclusion, JobInfo, JobStatus
 
@@ -119,6 +119,7 @@ def test_consume_raises_queue_error(monkeypatch: pytest.MonkeyPatch, queue_confi
             queue_config=queue_config,
             runner_manager=MagicMock(spec=consumer.RunnerManager),
             github_client=MagicMock(spec=consumer.GithubClient),
+            supported_labels={"label1", "label2"},
         )
     assert "Error when communicating with the queue" in str(exc_info.value)
 

--- a/tests/unit/reactive/test_process_manager.py
+++ b/tests/unit/reactive/test_process_manager.py
@@ -1,0 +1,191 @@
+#  Copyright 2024 Canonical Ltd.
+#  See LICENSE file for licensing details.
+import os
+import secrets
+import subprocess
+from pathlib import Path
+from subprocess import CompletedProcess
+from unittest.mock import MagicMock
+
+import pytest
+
+from github_runner_manager.reactive.process_manager import (
+    PIDS_COMMAND_LINE,
+    PYTHON_BIN,
+    REACTIVE_RUNNER_SCRIPT_MODULE,
+    ReactiveRunnerError,
+    reconcile,
+)
+from github_runner_manager.reactive.types_ import QueueConfig, RunnerConfig
+from github_runner_manager.utilities import secure_run_subprocess
+
+EXAMPLE_MQ_URI = "http://example.com"
+
+
+@pytest.fixture(name="log_dir", autouse=True)
+def log_dir_path_fixture(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Return the path to the log file."""
+    log_file_path = tmp_path / "logs"
+    monkeypatch.setattr(
+        "github_runner_manager.reactive.process_manager.REACTIVE_RUNNER_LOG_DIR", log_file_path
+    )
+    monkeypatch.setattr("shutil.chown", lambda *args, **kwargs: None)
+    return log_file_path
+
+
+@pytest.fixture(name="secure_run_subprocess_mock")
+def secure_run_subprocess_mock_fixture(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Mock the ps command."""
+    secure_run_subprocess_mock = MagicMock(spec=secure_run_subprocess)
+    monkeypatch.setattr(
+        "github_runner_manager.reactive.process_manager.secure_run_subprocess",
+        secure_run_subprocess_mock,
+    )
+    return secure_run_subprocess_mock
+
+
+@pytest.fixture(name="os_kill_mock", autouse=True)
+def os_kill_mock_fixture(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Mock the os.kill function."""
+    os_kill_mock = MagicMock(spec=os.kill)
+    monkeypatch.setattr("os.kill", os_kill_mock)
+    return os_kill_mock
+
+
+@pytest.fixture(name="subprocess_popen_mock")
+def subprocess_popen_mock_fixture(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Mock the subprocess.Popen function."""
+    popen_result = MagicMock(spec=subprocess.Popen, pid=1234, returncode=0)
+    subprocess_popen_mock = MagicMock(
+        spec=subprocess.Popen,
+        return_value=popen_result,
+    )
+    monkeypatch.setattr("subprocess.Popen", subprocess_popen_mock)
+    return subprocess_popen_mock
+
+
+@pytest.fixture(name="runner_config")
+def runner_config_fixture() -> RunnerConfig:
+    """Return a RunnerConfig object."""
+    queue_name = secrets.token_hex(16)
+
+    # we use construct to avoid pydantic validation as IN_MEMORY_URI is not a valid URL
+    queue_config = QueueConfig.construct(mongodb_uri=EXAMPLE_MQ_URI, queue_name=queue_name)
+    return RunnerConfig.construct(queue=queue_config)
+
+
+def test_reconcile_spawns_runners(
+    secure_run_subprocess_mock: MagicMock,
+    subprocess_popen_mock: MagicMock,
+    log_dir: Path,
+    runner_config: RunnerConfig,
+):
+    """
+    arrange: Mock that two reactive runner processes are active.
+    act: Call reconcile with a quantity of 5.
+    assert: Three runners are spawned. Log file is setup.
+    """
+    _arrange_reactive_processes(secure_run_subprocess_mock, count=2)
+
+    delta = reconcile(5, runner_config=runner_config)
+
+    assert delta == 3
+    assert subprocess_popen_mock.call_count == 3
+    assert log_dir.exists()
+
+
+def test_reconcile_does_not_spawn_runners(
+    secure_run_subprocess_mock: MagicMock,
+    subprocess_popen_mock: MagicMock,
+    runner_config: RunnerConfig,
+):
+    """
+    arrange: Mock that two reactive runner processes are active.
+    act: Call reconcile with a quantity of 2.
+    assert: No runners are spawned.
+    """
+    _arrange_reactive_processes(secure_run_subprocess_mock, count=2)
+
+    delta = reconcile(2, runner_config=runner_config)
+
+    assert delta == 0
+    assert subprocess_popen_mock.call_count == 0
+
+
+def test_reconcile_kills_processes_for_too_many_processes(
+    secure_run_subprocess_mock: MagicMock,
+    subprocess_popen_mock: MagicMock,
+    os_kill_mock: MagicMock,
+    runner_config: RunnerConfig,
+):
+    """
+    arrange: Mock that 3 reactive runner processes are active.
+    act: Call reconcile with a quantity of 1.
+    assert: 2 processes are killed.
+    """
+    _arrange_reactive_processes(secure_run_subprocess_mock, count=3)
+    delta = reconcile(1, runner_config=runner_config)
+
+    assert delta == -2
+    assert subprocess_popen_mock.call_count == 0
+    assert os_kill_mock.call_count == 2
+
+
+def test_reconcile_ignore_process_not_found_on_kill(
+    secure_run_subprocess_mock: MagicMock,
+    subprocess_popen_mock: MagicMock,
+    os_kill_mock: MagicMock,
+    runner_config: RunnerConfig,
+):
+    """
+    arrange: Mock 3 reactive processes and os.kill to fail once with a ProcessLookupError.
+    act: Call reconcile with a quantity of 1.
+    assert: The returned delta is still -2.
+    """
+    _arrange_reactive_processes(secure_run_subprocess_mock, count=3)
+    os_kill_mock.side_effect = [None, ProcessLookupError]
+    delta = reconcile(1, runner_config=runner_config)
+
+    assert delta == -2
+    assert subprocess_popen_mock.call_count == 0
+    assert os_kill_mock.call_count == 2
+
+
+def test_reconcile_raises_reactive_runner_error_on_ps_failure(
+    secure_run_subprocess_mock: MagicMock, runner_config: RunnerConfig
+):
+    """
+    arrange: Mock that the ps command fails.
+    act: Call reconcile with a quantity of 1.
+    assert: A ReactiveRunnerError is raised.
+    """
+    secure_run_subprocess_mock.return_value = CompletedProcess(
+        args=PIDS_COMMAND_LINE,
+        returncode=1,
+        stdout=b"",
+        stderr=b"error",
+    )
+
+    with pytest.raises(ReactiveRunnerError) as err:
+        reconcile(1, runner_config=runner_config)
+
+    assert "Failed to get list of processes" in str(err.value)
+
+
+def _arrange_reactive_processes(secure_run_subprocess_mock: MagicMock, count: int):
+    """Mock reactive runner processes are active.
+
+    Args:
+        secure_run_subprocess_mock: The mock to use for the ps command.
+        count: The number of processes.
+    """
+    process_cmds_before = "\n".join(
+        [f"{PYTHON_BIN} -m {REACTIVE_RUNNER_SCRIPT_MODULE}\t{i}" for i in range(count)]
+    )
+
+    secure_run_subprocess_mock.return_value = CompletedProcess(
+        args=PIDS_COMMAND_LINE,
+        returncode=0,
+        stdout=f"CMD\n{process_cmds_before}".encode("utf-8"),
+        stderr=b"",
+    )

--- a/tests/unit/reactive/test_runner_manager.py
+++ b/tests/unit/reactive/test_runner_manager.py
@@ -6,25 +6,30 @@ from unittest.mock import MagicMock
 import pytest
 
 import github_runner_manager.reactive.process_manager
-from github_runner_manager.manager.runner_manager import RunnerManager
+from github_runner_manager.manager.runner_manager import FlushMode, RunnerManager
 from github_runner_manager.reactive.runner_manager import reconcile
-from github_runner_manager.reactive.types_ import RunnerConfig
+from github_runner_manager.reactive.types_ import QueueConfig, RunnerConfig
 
 
 def test_reconcile(monkeypatch: pytest.MonkeyPatch):
     """
-    arrange: Mocked runner manager, reactive process manager, runner config and quantity.
-    act: Call reconcile.
+    arrange: Mock the dependencies.
+    act: Call reconcile with random quantity.
     assert: The cleanup method of runner manager is called and the reconcile method of
         process manager is called.
     """
     runner_manager = MagicMock(spec=RunnerManager)
     reactive_process_manager = MagicMock(spec=github_runner_manager.reactive.process_manager)
-    runner_config = MagicMock(RunnerConfig)
+    runner_config = MagicMock(spec=RunnerConfig)
+    runner_config.queue = MagicMock(spec=QueueConfig)
     quantity = randint(0, 10)
     monkeypatch.setattr(
         "github_runner_manager.reactive.runner_manager.process_manager",
         reactive_process_manager,
+    )
+    monkeypatch.setattr(
+        "github_runner_manager.reactive.runner_manager.get_queue_size",
+        lambda _: randint(1, 10),
     )
 
     reconcile(quantity, runner_manager, runner_config)
@@ -32,3 +37,28 @@ def test_reconcile(monkeypatch: pytest.MonkeyPatch):
     reactive_process_manager.reconcile.assert_called_once_with(
         quantity=quantity, runner_config=runner_config
     )
+
+
+def test_reconcile_flushes_idle_runners_when_queue_is_empty(monkeypatch: pytest.MonkeyPatch):
+    """
+    arrange: Mock the dependencies and set the queue size to 0.
+    act: Call reconcile with random quantity.
+    assert: The flush_runners method of runner manager is called with FLUSH_IDLE mode.
+    """
+    runner_manager = MagicMock(spec=RunnerManager)
+    reactive_process_manager = MagicMock(spec=github_runner_manager.reactive.process_manager)
+    runner_config = MagicMock(spec=RunnerConfig)
+    runner_config.queue = MagicMock(spec=QueueConfig)
+    quantity = randint(0, 10)
+    monkeypatch.setattr(
+        "github_runner_manager.reactive.runner_manager.process_manager",
+        reactive_process_manager,
+    )
+    monkeypatch.setattr(
+        "github_runner_manager.reactive.runner_manager.get_queue_size",
+        lambda _: 0,
+    )
+
+    reconcile(quantity, runner_manager, runner_config)
+
+    runner_manager.flush_runners.assert_called_once_with(FlushMode.FLUSH_IDLE)

--- a/tests/unit/reactive/test_runner_manager.py
+++ b/tests/unit/reactive/test_runner_manager.py
@@ -6,23 +6,40 @@ from unittest.mock import MagicMock
 import pytest
 
 import github_runner_manager.reactive.process_manager
-from github_runner_manager.manager.runner_manager import FlushMode, RunnerManager
+from github_runner_manager.manager.runner_manager import FlushMode, RunnerInstance, RunnerManager
 from github_runner_manager.reactive.runner_manager import reconcile
 from github_runner_manager.reactive.types_ import QueueConfig, RunnerConfig
 
 
-def test_reconcile(monkeypatch: pytest.MonkeyPatch):
+@pytest.mark.parametrize(
+    "runner_quantity, desired_quantity, expected_process_quantity",
+    [
+        pytest.param(5, 5, 0, id="zero processes to spawn"),
+        pytest.param(5, 10, 5, id="5 processes to spawn"),
+        pytest.param(5, 7, 2, id="2 processes to spawn"),
+        pytest.param(0, 5, 5, id="no runners running"),
+        pytest.param(0, 0, 0, id="zero quantity"),
+    ],
+)
+def test_reconcile_positive_runner_diff(
+    runner_quantity: int,
+    desired_quantity: int,
+    expected_process_quantity: int,
+    monkeypatch: pytest.MonkeyPatch,
+):
     """
-    arrange: Mock the dependencies.
-    act: Call reconcile with random quantity.
+    arrange: Mock the difference of amount of runners and desired quantity to be positive.
+    act: Call reconcile.
     assert: The cleanup method of runner manager is called and the reconcile method of
-        process manager is called.
+        process manager is called with the expected quantity.
     """
     runner_manager = MagicMock(spec=RunnerManager)
+    runner_manager.get_runners = MagicMock(
+        return_value=(tuple(MagicMock(spec=RunnerInstance) for _ in range(runner_quantity)))
+    )
     reactive_process_manager = MagicMock(spec=github_runner_manager.reactive.process_manager)
     runner_config = MagicMock(spec=RunnerConfig)
     runner_config.queue = MagicMock(spec=QueueConfig)
-    quantity = randint(0, 10)
     monkeypatch.setattr(
         "github_runner_manager.reactive.runner_manager.process_manager",
         reactive_process_manager,
@@ -32,10 +49,54 @@ def test_reconcile(monkeypatch: pytest.MonkeyPatch):
         lambda _: randint(1, 10),
     )
 
-    reconcile(quantity, runner_manager, runner_config)
+    reconcile(desired_quantity, runner_manager, runner_config)
     runner_manager.cleanup.assert_called_once()
     reactive_process_manager.reconcile.assert_called_once_with(
-        quantity=quantity, runner_config=runner_config
+        quantity=expected_process_quantity, runner_config=runner_config
+    )
+
+
+@pytest.mark.parametrize(
+    "runner_quantity, desired_quantity, expected_number_of_runners_to_delete",
+    [
+        pytest.param(6, 5, 1, id="one additional runner"),
+        pytest.param(8, 5, 3, id="multiple additional runners"),
+        pytest.param(10, 0, 10, id="zero desired quantity"),
+    ],
+)
+def test_reconcile_negative_runner_diff(
+    runner_quantity: int,
+    desired_quantity: int,
+    expected_number_of_runners_to_delete: int,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """
+    arrange: Mock the difference of amount of runners and desired quantity to be negative.
+    act: Call reconcile.
+    assert: The additional amount of runners are deleted and the reconcile method of the
+        process manager is called with zero quantity.
+    """
+    runner_manager = MagicMock(spec=RunnerManager)
+    runner_manager.get_runners = MagicMock(
+        return_value=(tuple(MagicMock(spec=RunnerInstance) for _ in range(runner_quantity)))
+    )
+    reactive_process_manager = MagicMock(spec=github_runner_manager.reactive.process_manager)
+    runner_config = MagicMock(spec=RunnerConfig)
+    runner_config.queue = MagicMock(spec=QueueConfig)
+    monkeypatch.setattr(
+        "github_runner_manager.reactive.runner_manager.process_manager",
+        reactive_process_manager,
+    )
+    monkeypatch.setattr(
+        "github_runner_manager.reactive.runner_manager.get_queue_size",
+        lambda _: randint(1, 10),
+    )
+
+    reconcile(desired_quantity, runner_manager, runner_config)
+    runner_manager.cleanup.assert_called_once()
+    runner_manager.delete_runners.assert_called_once_with(expected_number_of_runners_to_delete)
+    reactive_process_manager.reconcile.assert_called_once_with(
+        quantity=0, runner_config=runner_config
     )
 
 

--- a/tests/unit/reactive/test_runner_manager.py
+++ b/tests/unit/reactive/test_runner_manager.py
@@ -1,191 +1,34 @@
 #  Copyright 2024 Canonical Ltd.
 #  See LICENSE file for licensing details.
-import os
-import secrets
-import subprocess
-from pathlib import Path
-from subprocess import CompletedProcess
+from random import randint
 from unittest.mock import MagicMock
 
 import pytest
 
-from github_runner_manager.reactive.runner_manager import (
-    PIDS_COMMAND_LINE,
-    PYTHON_BIN,
-    REACTIVE_RUNNER_SCRIPT_MODULE,
-    ReactiveRunnerError,
-    reconcile,
-)
-from github_runner_manager.reactive.types_ import QueueConfig, RunnerConfig
-from github_runner_manager.utilities import secure_run_subprocess
-
-EXAMPLE_MQ_URI = "http://example.com"
+import github_runner_manager.reactive.process_manager
+from github_runner_manager.manager.runner_manager import RunnerManager
+from github_runner_manager.reactive.runner_manager import reconcile
+from github_runner_manager.reactive.types_ import RunnerConfig
 
 
-@pytest.fixture(name="log_dir", autouse=True)
-def log_dir_path_fixture(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """Return the path to the log file."""
-    log_file_path = tmp_path / "logs"
+def test_reconcile(monkeypatch: pytest.MonkeyPatch):
+    """
+    arrange: Mocked runner manager, reactive process manager, runner config and quantity.
+    act: Call reconcile.
+    assert: The cleanup method of runner manager is called and the reconcile method of
+        process manager is called.
+    """
+    runner_manager = MagicMock(spec=RunnerManager)
+    reactive_process_manager = MagicMock(spec=github_runner_manager.reactive.process_manager)
+    runner_config = MagicMock(RunnerConfig)
+    quantity = randint(0, 10)
     monkeypatch.setattr(
-        "github_runner_manager.reactive.runner_manager.REACTIVE_RUNNER_LOG_DIR", log_file_path
-    )
-    monkeypatch.setattr("shutil.chown", lambda *args, **kwargs: None)
-    return log_file_path
-
-
-@pytest.fixture(name="secure_run_subprocess_mock")
-def secure_run_subprocess_mock_fixture(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
-    """Mock the ps command."""
-    secure_run_subprocess_mock = MagicMock(spec=secure_run_subprocess)
-    monkeypatch.setattr(
-        "github_runner_manager.reactive.runner_manager.secure_run_subprocess",
-        secure_run_subprocess_mock,
-    )
-    return secure_run_subprocess_mock
-
-
-@pytest.fixture(name="os_kill_mock", autouse=True)
-def os_kill_mock_fixture(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
-    """Mock the os.kill function."""
-    os_kill_mock = MagicMock(spec=os.kill)
-    monkeypatch.setattr("os.kill", os_kill_mock)
-    return os_kill_mock
-
-
-@pytest.fixture(name="subprocess_popen_mock")
-def subprocess_popen_mock_fixture(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
-    """Mock the subprocess.Popen function."""
-    popen_result = MagicMock(spec=subprocess.Popen, pid=1234, returncode=0)
-    subprocess_popen_mock = MagicMock(
-        spec=subprocess.Popen,
-        return_value=popen_result,
-    )
-    monkeypatch.setattr("subprocess.Popen", subprocess_popen_mock)
-    return subprocess_popen_mock
-
-
-@pytest.fixture(name="runner_config")
-def runner_config_fixture() -> RunnerConfig:
-    """Return a RunnerConfig object."""
-    queue_name = secrets.token_hex(16)
-
-    # we use construct to avoid pydantic validation as IN_MEMORY_URI is not a valid URL
-    queue_config = QueueConfig.construct(mongodb_uri=EXAMPLE_MQ_URI, queue_name=queue_name)
-    return RunnerConfig.construct(queue=queue_config)
-
-
-def test_reconcile_spawns_runners(
-    secure_run_subprocess_mock: MagicMock,
-    subprocess_popen_mock: MagicMock,
-    log_dir: Path,
-    runner_config: RunnerConfig,
-):
-    """
-    arrange: Mock that two reactive runner processes are active.
-    act: Call reconcile with a quantity of 5.
-    assert: Three runners are spawned. Log file is setup.
-    """
-    _arrange_reactive_processes(secure_run_subprocess_mock, count=2)
-
-    delta = reconcile(5, runner_config=runner_config)
-
-    assert delta == 3
-    assert subprocess_popen_mock.call_count == 3
-    assert log_dir.exists()
-
-
-def test_reconcile_does_not_spawn_runners(
-    secure_run_subprocess_mock: MagicMock,
-    subprocess_popen_mock: MagicMock,
-    runner_config: RunnerConfig,
-):
-    """
-    arrange: Mock that two reactive runner processes are active.
-    act: Call reconcile with a quantity of 2.
-    assert: No runners are spawned.
-    """
-    _arrange_reactive_processes(secure_run_subprocess_mock, count=2)
-
-    delta = reconcile(2, runner_config=runner_config)
-
-    assert delta == 0
-    assert subprocess_popen_mock.call_count == 0
-
-
-def test_reconcile_kills_processes_for_too_many_processes(
-    secure_run_subprocess_mock: MagicMock,
-    subprocess_popen_mock: MagicMock,
-    os_kill_mock: MagicMock,
-    runner_config: RunnerConfig,
-):
-    """
-    arrange: Mock that 3 reactive runner processes are active.
-    act: Call reconcile with a quantity of 1.
-    assert: 2 processes are killed.
-    """
-    _arrange_reactive_processes(secure_run_subprocess_mock, count=3)
-    delta = reconcile(1, runner_config=runner_config)
-
-    assert delta == -2
-    assert subprocess_popen_mock.call_count == 0
-    assert os_kill_mock.call_count == 2
-
-
-def test_reconcile_ignore_process_not_found_on_kill(
-    secure_run_subprocess_mock: MagicMock,
-    subprocess_popen_mock: MagicMock,
-    os_kill_mock: MagicMock,
-    runner_config: RunnerConfig,
-):
-    """
-    arrange: Mock 3 reactive processes and os.kill to fail once with a ProcessLookupError.
-    act: Call reconcile with a quantity of 1.
-    assert: The returned delta is still -2.
-    """
-    _arrange_reactive_processes(secure_run_subprocess_mock, count=3)
-    os_kill_mock.side_effect = [None, ProcessLookupError]
-    delta = reconcile(1, runner_config=runner_config)
-
-    assert delta == -2
-    assert subprocess_popen_mock.call_count == 0
-    assert os_kill_mock.call_count == 2
-
-
-def test_reconcile_raises_reactive_runner_error_on_ps_failure(
-    secure_run_subprocess_mock: MagicMock, runner_config: RunnerConfig
-):
-    """
-    arrange: Mock that the ps command fails.
-    act: Call reconcile with a quantity of 1.
-    assert: A ReactiveRunnerError is raised.
-    """
-    secure_run_subprocess_mock.return_value = CompletedProcess(
-        args=PIDS_COMMAND_LINE,
-        returncode=1,
-        stdout=b"",
-        stderr=b"error",
+        "github_runner_manager.reactive.runner_manager.process_manager",
+        reactive_process_manager,
     )
 
-    with pytest.raises(ReactiveRunnerError) as err:
-        reconcile(1, runner_config=runner_config)
-
-    assert "Failed to get list of processes" in str(err.value)
-
-
-def _arrange_reactive_processes(secure_run_subprocess_mock: MagicMock, count: int):
-    """Mock reactive runner processes are active.
-
-    Args:
-        secure_run_subprocess_mock: The mock to use for the ps command.
-        count: The number of processes.
-    """
-    process_cmds_before = "\n".join(
-        [f"{PYTHON_BIN} -m {REACTIVE_RUNNER_SCRIPT_MODULE}\t{i}" for i in range(count)]
-    )
-
-    secure_run_subprocess_mock.return_value = CompletedProcess(
-        args=PIDS_COMMAND_LINE,
-        returncode=0,
-        stdout=f"CMD\n{process_cmds_before}".encode("utf-8"),
-        stderr=b"",
+    reconcile(quantity, runner_manager, runner_config)
+    runner_manager.cleanup.assert_called_once()
+    reactive_process_manager.reconcile.assert_called_once_with(
+        quantity=quantity, runner_config=runner_config
     )


### PR DESCRIPTION
Applicable spec: [ISD-116](https://discourse.charmhub.io/t/specification-isd116-github-self-hosted-runners-reactive-scheduling/13755)

### Overview

Further implement/enhance reconciliation in reactive mode.

Successful integration test: https://github.com/canonical/github-runner-operator/actions/runs/11179405894

### Rationale

The current reconciliation only spawns/kills reactive processes without taking into account that there may be runners still alive.
Another optimisation is to flush idle runners when there are no jobs in the queue.

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library/Dependency Changes

<!-- Any changes to libraries -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The library version in `pyproject.toml` is incremented

<!-- Explanation for any unchecked items above -->


[ISD-116]: https://warthogs.atlassian.net/browse/ISD-116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ