### PR TITLE
fix: add apt-update to userdata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "github-runner-manager"
-version = "0.3.0"
+version = "0.3.1"
 authors = [
     { name = "Canonical IS DevOps", email = "is-devops-team@canonical.com" },
 ]

--- a/src/github_runner_manager/templates/openstack-userdata.sh.j2
+++ b/src/github_runner_manager/templates/openstack-userdata.sh.j2
@@ -2,7 +2,6 @@
 
 set -e
 
-sudo apt-get update
 hostnamectl set-hostname github-runner
 
 # Write .env contents
@@ -31,6 +30,8 @@ EOF
 systemctl enable nftables.service
 nft -f /etc/nftables.conf
 {% endif %}
+
+sudo apt-get update
 
 adduser ubuntu lxd
 adduser ubuntu adm

--- a/src/github_runner_manager/templates/openstack-userdata.sh.j2
+++ b/src/github_runner_manager/templates/openstack-userdata.sh.j2
@@ -2,6 +2,7 @@
 
 set -e
 
+sudo apt-get update
 hostnamectl set-hostname github-runner
 
 # Write .env contents


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Add `apt-get update` to cloud-init.
<!-- A high level overview of the change -->

### Rationale

- On snapshot images apt update cache does not get carried over.

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library/Dependency Changes

<!-- Any changes to libraries -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The library version in `pyproject.toml` is incremented

<!-- Explanation for any unchecked items above -->
