### PR TITLE
fix: chown of existing reactive runner log dir

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "github-runner-manager"
-version = "0.4.1"
+version = "0.4.2"
 authors = [
     { name = "Canonical IS DevOps", email = "is-devops-team@canonical.com" },
 ]

--- a/src/github_runner_manager/reactive/process_manager.py
+++ b/src/github_runner_manager/reactive/process_manager.py
@@ -113,11 +113,10 @@ def _setup_logging_for_processes(system_user_config: SystemUserConfig) -> None:
     Args:
         system_user_config: The configuration to decide which user to use to create the log dir.
     """
-    if not REACTIVE_RUNNER_LOG_DIR.exists():
-        REACTIVE_RUNNER_LOG_DIR.mkdir()
-        shutil.chown(
-            REACTIVE_RUNNER_LOG_DIR, user=system_user_config.user, group=system_user_config.group
-        )
+    REACTIVE_RUNNER_LOG_DIR.mkdir(exist_ok=True)
+    shutil.chown(
+        REACTIVE_RUNNER_LOG_DIR, user=system_user_config.user, group=system_user_config.group
+    )
 
 
 def _spawn_runner(runner_config: RunnerConfig) -> None:


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Change the ownership of any existing reactive runner log dir


(tests: https://github.com/canonical/github-runner-operator/actions/runs/11433983359)
### Rationale

to allow upgrading from previous charm revisions (where the dir had different ownership).


### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The library version in `pyproject.toml` is incremented

<!-- Explanation for any unchecked items above -->
