### PR TITLE
fix: Use datetime.fromisoformat in server uniqueness check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "github-runner-manager"
-version = "0.4.1"
+version = "0.4.2"
 authors = [
     { name = "Canonical IS DevOps", email = "is-devops-team@canonical.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "github-runner-manager"
-version = "0.4.2"
+version = "0.4.3"
 authors = [
     { name = "Canonical IS DevOps", email = "is-devops-team@canonical.com" },
 ]

--- a/src/github_runner_manager/openstack_cloud/openstack_cloud.py
+++ b/src/github_runner_manager/openstack_cloud/openstack_cloud.py
@@ -446,7 +446,8 @@ class OpenstackCloud:
         latest_server = reduce(
             lambda a, b: (
                 a
-                if datetime.fromisoformat(a.created_at) < datetime.fromisoformat(b.create_at)
+                if datetime.fromisoformat(a.created_at.replace("Z", "+00:00"))
+                < datetime.fromisoformat(b.created_at.replace("Z", "+00:00"))
                 else b
             ),
             servers,

--- a/src/github_runner_manager/openstack_cloud/openstack_cloud.py
+++ b/src/github_runner_manager/openstack_cloud/openstack_cloud.py
@@ -443,13 +443,10 @@ class OpenstackCloud:
         if not servers:
             return None
 
-        # 2024/08/14: The `format` arg for `strptime` is the default format.
-        # This is only provided to get around a bug of the function with type checking.
         latest_server = reduce(
             lambda a, b: (
                 a
-                if datetime.fromisoformat(a.created_at)
-                < datetime.fromisoformat(b.create_at)
+                if datetime.fromisoformat(a.created_at) < datetime.fromisoformat(b.create_at)
                 else b
             ),
             servers,

--- a/src/github_runner_manager/openstack_cloud/openstack_cloud.py
+++ b/src/github_runner_manager/openstack_cloud/openstack_cloud.py
@@ -448,8 +448,8 @@ class OpenstackCloud:
         latest_server = reduce(
             lambda a, b: (
                 a
-                if datetime.strptime(a.created_at, "a %b %d %H:%M:%S %Y")
-                < datetime.strptime(b.create_at, "a %b %d %H:%M:%S %Y")
+                if datetime.fromisoformat(a.created_at)
+                < datetime.fromisoformat(b.create_at)
                 else b
             ),
             servers,


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Use `datetime.fromisoformat` in `_get_and_ensure_unique_server` check.

@yanksyoon Tested the code succesfully manually.

### Rationale

We got a production issue where the check fails due to using the wrong dateformat in strptime.

```
2024-10-23 08:50:43.891	
2024-10-23 06:50:43 ERROR unit.openstack-amd64-edge-ps5/0.juju-log server.go:325 Uncaught exception while in charm code:

2024-10-23 08:50:43.891	
Traceback (most recent call last):
2024-10-23 08:50:43.891	
  File "/var/lib/juju/agents/unit-openstack-amd64-edge-ps5-0/charm/venv/github_runner_manager/manager/runner_scaler.py", line 156, in reconcile
2024-10-23 08:50:43.891	
    reconcile_result = self._reconcile_non_reactive(quantity)
2024-10-23 08:50:43.891	
  File "/var/lib/juju/agents/unit-openstack-amd64-edge-ps5-0/charm/venv/github_runner_manager/manager/runner_scaler.py", line 179, in _reconcile_non_reactive
2024-10-23 08:50:43.891	
    metric_stats = self._manager.cleanup()
2024-10-23 08:50:43.891	
  File "/var/lib/juju/agents/unit-openstack-amd64-edge-ps5-0/charm/venv/github_runner_manager/manager/runner_manager.py", line 250, in cleanup
2024-10-23 08:50:43.891	
    deleted_runner_metrics = self._cloud.cleanup(remove_token)
2024-10-23 08:50:43.891	
  File "/var/lib/juju/agents/unit-openstack-amd64-edge-ps5-0/charm/venv/github_runner_manager/openstack_cloud/openstack_runner_manager.py", line 360, in cleanup
2024-10-23 08:50:43.891	
    runners = self._get_runners_health()
2024-10-23 08:50:43.891	
  File "/var/lib/juju/agents/unit-openstack-amd64-edge-ps5-0/charm/venv/github_runner_manager/openstack_cloud/openstack_runner_manager.py", line 463, in _get_runners_health
2024-10-23 08:50:43.891	
    runner_list = self._openstack_cloud.get_instances()
2024-10-23 08:50:43.891	
  File "/var/lib/juju/agents/unit-openstack-amd64-edge-ps5-0/charm/venv/github_runner_manager/openstack_cloud/openstack_cloud.py", line 336, in get_instances
2024-10-23 08:50:43.891	
    server_list = [
2024-10-23 08:50:43.891	
  File "/var/lib/juju/agents/unit-openstack-amd64-edge-ps5-0/charm/venv/github_runner_manager/openstack_cloud/openstack_cloud.py", line 337, in <listcomp>
2024-10-23 08:50:43.891	
    OpenstackCloud._get_and_ensure_unique_server(conn, name) for name in server_names
2024-10-23 08:50:43.891	
  File "/var/lib/juju/agents/unit-openstack-amd64-edge-ps5-0/charm/venv/github_runner_manager/openstack_cloud/openstack_cloud.py", line 448, in _get_and_ensure_unique_server
2024-10-23 08:50:43.891	
    latest_server = reduce(
2024-10-23 08:50:43.891	
  File "/var/lib/juju/agents/unit-openstack-amd64-edge-ps5-0/charm/venv/github_runner_manager/openstack_cloud/openstack_cloud.py", line 451, in <lambda>
2024-10-23 08:50:43.891	
    if datetime.strptime(a.created_at, "a %b %d %H:%M:%S %Y")
2024-10-23 08:50:43.891	
  File "/usr/lib/python3.10/_strptime.py", line 568, in _strptime_datetime
2024-10-23 08:50:43.891	
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
2024-10-23 08:50:43.891	
  File "/usr/lib/python3.10/_strptime.py", line 349, in _strptime
2024-10-23 08:50:43.891	
    raise ValueError("time data %r does not match format %r" %
2024-10-23 08:50:43.891	
ValueError: time data '2024-10-22T09:38:18Z' does not match format 'a %b %d %H:%M:%S %Y
```



### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The library version in `pyproject.toml` is incremented

<!-- Explanation for any unchecked items above -->
