### PR TITLE
Include number of expected runners in reconciliation metric

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "github-runner-manager"
-version = "0.4.3"
+version = "0.5.0"
 authors = [
     { name = "Canonical IS DevOps", email = "is-devops-team@canonical.com" },
 ]

--- a/src-docs/manager.runner_scaler.md
+++ b/src-docs/manager.runner_scaler.md
@@ -50,12 +50,12 @@ __init__(
 
 ---
 
-<a href="../src/github_runner_manager/manager/runner_scaler.py#L60"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/manager/runner_scaler.py#L82"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `RunnerScaler`
 Manage the reconcile of runners. 
 
-<a href="../src/github_runner_manager/manager/runner_scaler.py#L63"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/manager/runner_scaler.py#L85"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `__init__`
 
@@ -80,7 +80,7 @@ Construct the object.
 
 ---
 
-<a href="../src/github_runner_manager/manager/runner_scaler.py#L111"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/manager/runner_scaler.py#L133"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `flush`
 
@@ -103,7 +103,7 @@ Flush the runners.
 
 ---
 
-<a href="../src/github_runner_manager/manager/runner_scaler.py#L75"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/manager/runner_scaler.py#L97"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `get_runner_info`
 
@@ -120,7 +120,7 @@ Get information on the runners.
 
 ---
 
-<a href="../src/github_runner_manager/manager/runner_scaler.py#L129"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/manager/runner_scaler.py#L151"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `reconcile`
 

--- a/src-docs/metrics.events.md
+++ b/src-docs/metrics.events.md
@@ -8,7 +8,7 @@ Models and functions for the metric events.
 
 ---
 
-<a href="../src/github_runner_manager/metrics/events.py#L154"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/metrics/events.py#L157"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `issue_event`
 
@@ -217,6 +217,7 @@ Metric event for when the charm has finished reconciliation.
  - <b>`crashed_runners`</b>:  The number of crashed runners. 
  - <b>`idle_runners`</b>:  The number of idle runners. 
  - <b>`active_runners`</b>:  The number of active runners. 
+ - <b>`expected_runners`</b>:  The expected number of runners. This is optional as it is not suitable  for reactive runners. 
  - <b>`duration`</b>:  The duration of the reconciliation in seconds. 
 
 <a href="../src/github_runner_manager/metrics/events.py#L48"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>

--- a/src/github_runner_manager/manager/runner_scaler.py
+++ b/src/github_runner_manager/manager/runner_scaler.py
@@ -57,6 +57,28 @@ class _ReconcileResult:
     metric_stats: IssuedMetricEventsStats
 
 
+@dataclass
+class _ReconcileMetricData:
+    """Data used to issue the reconciliation metric.
+
+    Attributes:
+        start_timestamp: The start timestamp of the reconciliation.
+        end_timestamp: The end timestamp of the reconciliation.
+        metric_stats: The metric stats issued by the runner manager.
+        runner_list: The list of runners in the cloud.
+        flavor: The name of the flavor in the reconciliation event.
+        expected_runner_quantity: The expected number of runners.
+            May be None if reactive mode is enabled.
+    """
+
+    start_timestamp: float
+    end_timestamp: float
+    metric_stats: IssuedMetricEventsStats
+    runner_list: tuple[RunnerInstance]
+    flavor: str
+    expected_runner_quantity: int | None = None
+
+
 class RunnerScaler:
     """Manage the reconcile of runners."""
 
@@ -162,13 +184,15 @@ class RunnerScaler:
             runner_list = self._manager.get_runners()
             self._log_runners(runner_list)
             end_timestamp = time.time()
-            self._issue_reconciliation_metric(
+            reconcile_metric_data = _ReconcileMetricData(
                 start_timestamp=start_timestamp,
                 end_timestamp=end_timestamp,
                 metric_stats=metric_stats,
                 runner_list=runner_list,
+                flavor=self._manager.manager_name,
                 expected_runner_quantity=expected_runner_quantity,
             )
+            _issue_reconciliation_metric(reconcile_metric_data)
 
         return reconcile_diff
 
@@ -244,53 +268,52 @@ class RunnerScaler:
         )
         logger.info("Found %s unhealthy runners: %s", len(unhealthy_runners), unhealthy_runners)
 
-    def _issue_reconciliation_metric(
-        self,
-        start_timestamp: float,
-        end_timestamp: float,
-        metric_stats: IssuedMetricEventsStats,
-        runner_list: tuple[RunnerInstance],
-        expected_runner_quantity: int | None = None,
-    ) -> None:
-        """Issue the reconciliation metric.
 
-        Args:
-            start_timestamp: The start timestamp of the reconciliation.
-            end_timestamp: The end timestamp of the reconciliation.
-            metric_stats: The metric stats.
-            runner_list: The list of runners.
-            expected_runner_quantity: The expected number of runners.
-        """
-        idle_runners = {
-            runner.name for runner in runner_list if runner.github_state == GitHubRunnerState.IDLE
-        }
+def _issue_reconciliation_metric(
+    reconcile_metric_data: _ReconcileMetricData,
+) -> None:
+    """Issue the reconciliation metric.
 
-        offline_healthy_runners = {
-            runner.name
-            for runner in runner_list
-            if runner.github_state == GitHubRunnerState.OFFLINE
-            and runner.health == HealthState.HEALTHY
-        }
-        available_runners = idle_runners | offline_healthy_runners
-        active_runners = {
-            runner.name for runner in runner_list if runner.github_state == GitHubRunnerState.BUSY
-        }
-        logger.info("Current available runners (idle + healthy offline): %s", available_runners)
-        logger.info("Current active runners: %s", active_runners)
+    Args:
+        reconcile_metric_data: The data used to issue the reconciliation metric.
+    """
+    idle_runners = {
+        runner.name
+        for runner in reconcile_metric_data.runner_list
+        if runner.github_state == GitHubRunnerState.IDLE
+    }
 
-        try:
+    offline_healthy_runners = {
+        runner.name
+        for runner in reconcile_metric_data.runner_list
+        if runner.github_state == GitHubRunnerState.OFFLINE
+        and runner.health == HealthState.HEALTHY
+    }
+    available_runners = idle_runners | offline_healthy_runners
+    active_runners = {
+        runner.name
+        for runner in reconcile_metric_data.runner_list
+        if runner.github_state == GitHubRunnerState.BUSY
+    }
+    logger.info("Current available runners (idle + healthy offline): %s", available_runners)
+    logger.info("Current active runners: %s", active_runners)
 
-            metric_events.issue_event(
-                metric_events.Reconciliation(
-                    timestamp=time.time(),
-                    flavor=self._manager.manager_name,
-                    crashed_runners=metric_stats.get(metric_events.RunnerStart, 0)
-                    - metric_stats.get(metric_events.RunnerStop, 0),
-                    idle_runners=len(available_runners),
-                    active_runners=len(active_runners),
-                    expected_runners=expected_runner_quantity,
-                    duration=end_timestamp - start_timestamp,
+    try:
+
+        metric_events.issue_event(
+            metric_events.Reconciliation(
+                timestamp=time.time(),
+                flavor=reconcile_metric_data.flavor,
+                crashed_runners=reconcile_metric_data.metric_stats.get(
+                    metric_events.RunnerStart, 0
                 )
+                - reconcile_metric_data.metric_stats.get(metric_events.RunnerStop, 0),
+                idle_runners=len(available_runners),
+                active_runners=len(active_runners),
+                expected_runners=reconcile_metric_data.expected_runner_quantity,
+                duration=reconcile_metric_data.end_timestamp
+                - reconcile_metric_data.start_timestamp,
             )
-        except IssueMetricEventError:
-            logger.exception("Failed to issue Reconciliation metric")
+        )
+    except IssueMetricEventError:
+        logger.exception("Failed to issue Reconciliation metric")

--- a/src/github_runner_manager/manager/runner_scaler.py
+++ b/src/github_runner_manager/manager/runner_scaler.py
@@ -140,6 +140,8 @@ class RunnerScaler:
         metric_stats = {}
         start_timestamp = time.time()
 
+        expected_runner_quantity = quantity if self._reactive_config is None else None
+
         try:
             if self._reactive_config is not None:
                 logger.info(
@@ -161,7 +163,11 @@ class RunnerScaler:
             self._log_runners(runner_list)
             end_timestamp = time.time()
             self._issue_reconciliation_metric(
-                start_timestamp, end_timestamp, metric_stats, runner_list
+                start_timestamp=start_timestamp,
+                end_timestamp=end_timestamp,
+                metric_stats=metric_stats,
+                runner_list=runner_list,
+                expected_runner_quantity=expected_runner_quantity,
             )
 
         return reconcile_diff
@@ -244,6 +250,7 @@ class RunnerScaler:
         end_timestamp: float,
         metric_stats: IssuedMetricEventsStats,
         runner_list: tuple[RunnerInstance],
+        expected_runner_quantity: int | None = None,
     ) -> None:
         """Issue the reconciliation metric.
 
@@ -252,6 +259,7 @@ class RunnerScaler:
             end_timestamp: The end timestamp of the reconciliation.
             metric_stats: The metric stats.
             runner_list: The list of runners.
+            expected_runner_quantity: The expected number of runners.
         """
         idle_runners = {
             runner.name for runner in runner_list if runner.github_state == GitHubRunnerState.IDLE
@@ -280,6 +288,7 @@ class RunnerScaler:
                     - metric_stats.get(metric_events.RunnerStop, 0),
                     idle_runners=len(available_runners),
                     active_runners=len(active_runners),
+                    expected_runners=expected_runner_quantity,
                     duration=end_timestamp - start_timestamp,
                 )
             )

--- a/src/github_runner_manager/metrics/events.py
+++ b/src/github_runner_manager/metrics/events.py
@@ -141,6 +141,8 @@ class Reconciliation(Event):
         crashed_runners: The number of crashed runners.
         idle_runners: The number of idle runners.
         active_runners: The number of active runners.
+        expected_runners: The expected number of runners. This is optional as it is not suitable
+            for reactive runners.
         duration: The duration of the reconciliation in seconds.
     """
 
@@ -148,6 +150,7 @@ class Reconciliation(Event):
     crashed_runners: int
     idle_runners: int
     active_runners: int
+    expected_runners: int | None
     duration: NonNegativeFloat
 
 


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Include expected runners in reconciliation metric

(Integration test runs: https://github.com/canonical/github-runner-operator/actions/runs/11498315403/)
### Rationale

to improve observability

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library/Dependency Changes

<!-- Any changes to libraries -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The library version in `pyproject.toml` is incremented

<!-- Explanation for any unchecked items above -->
