### PR TITLE
Catch Openstack API errors in reconcile

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "github-runner-manager"
-version = "0.5.0"
+version = "0.5.1"
 authors = [
     { name = "Canonical IS DevOps", email = "is-devops-team@canonical.com" },
 ]

--- a/src-docs/errors.md
+++ b/src-docs/errors.md
@@ -251,7 +251,7 @@ Represents missing keyfile for SSH.
 
 ---
 
-<a href="../src/github_runner_manager/errors.py#L95"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/errors.py#L96"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `ReconcileError`
 Base class for all reconcile errors. 

--- a/src-docs/errors.md
+++ b/src-docs/errors.md
@@ -249,3 +249,14 @@ Represents missing keyfile for SSH.
 
 
 
+---
+
+<a href="../src/github_runner_manager/errors.py#L95"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `ReconcileError`
+Base class for all reconcile errors. 
+
+
+
+
+

--- a/src-docs/errors.md
+++ b/src-docs/errors.md
@@ -198,6 +198,17 @@ Represents an error when the job could not be found on GitHub.
 
 <a href="../src/github_runner_manager/errors.py#L76"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
+## <kbd>class</kbd> `CloudError`
+Base class for cloud (as e.g. OpenStack) errors. 
+
+
+
+
+
+---
+
+<a href="../src/github_runner_manager/errors.py#L80"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
 ## <kbd>class</kbd> `OpenStackError`
 Base class for OpenStack errors. 
 
@@ -207,7 +218,7 @@ Base class for OpenStack errors.
 
 ---
 
-<a href="../src/github_runner_manager/errors.py#L80"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/errors.py#L84"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `OpenStackInvalidConfigError`
 Represents an invalid OpenStack configuration. 
@@ -218,7 +229,7 @@ Represents an invalid OpenStack configuration.
 
 ---
 
-<a href="../src/github_runner_manager/errors.py#L84"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/errors.py#L88"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `SSHError`
 Represents an error while interacting with SSH. 
@@ -229,7 +240,7 @@ Represents an error while interacting with SSH.
 
 ---
 
-<a href="../src/github_runner_manager/errors.py#L88"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/errors.py#L92"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `KeyfileError`
 Represents missing keyfile for SSH. 

--- a/src-docs/manager.runner_scaler.md
+++ b/src-docs/manager.runner_scaler.md
@@ -142,3 +142,9 @@ Reconcile the quantity of runners.
  The Change in number of runners or reactive processes. 
 
 
+
+**Raises:**
+ 
+ - <b>`ReconcileError`</b>:  If an expected error occurred during the reconciliation. 
+
+

--- a/src-docs/manager.runner_scaler.md
+++ b/src-docs/manager.runner_scaler.md
@@ -9,7 +9,7 @@ Module for scaling the runners amount.
 
 ---
 
-<a href="../src/github_runner_manager/manager/runner_scaler.py#L30"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/manager/runner_scaler.py#L31"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `RunnerInfo`
 Information on the runners. 
@@ -50,12 +50,12 @@ __init__(
 
 ---
 
-<a href="../src/github_runner_manager/manager/runner_scaler.py#L86"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/manager/runner_scaler.py#L87"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `RunnerScaler`
 Manage the reconcile of runners. 
 
-<a href="../src/github_runner_manager/manager/runner_scaler.py#L89"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/manager/runner_scaler.py#L90"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `__init__`
 
@@ -80,7 +80,7 @@ Construct the object.
 
 ---
 
-<a href="../src/github_runner_manager/manager/runner_scaler.py#L137"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/manager/runner_scaler.py#L138"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `flush`
 
@@ -103,7 +103,7 @@ Flush the runners.
 
 ---
 
-<a href="../src/github_runner_manager/manager/runner_scaler.py#L101"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/manager/runner_scaler.py#L102"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `get_runner_info`
 
@@ -120,7 +120,7 @@ Get information on the runners.
 
 ---
 
-<a href="../src/github_runner_manager/manager/runner_scaler.py#L155"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/manager/runner_scaler.py#L156"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `reconcile`
 

--- a/src-docs/manager.runner_scaler.md
+++ b/src-docs/manager.runner_scaler.md
@@ -9,7 +9,7 @@ Module for scaling the runners amount.
 
 ---
 
-<a href="../src/github_runner_manager/manager/runner_scaler.py#L26"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/manager/runner_scaler.py#L30"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `RunnerInfo`
 Information on the runners. 
@@ -50,12 +50,12 @@ __init__(
 
 ---
 
-<a href="../src/github_runner_manager/manager/runner_scaler.py#L82"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/manager/runner_scaler.py#L86"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `RunnerScaler`
 Manage the reconcile of runners. 
 
-<a href="../src/github_runner_manager/manager/runner_scaler.py#L85"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/manager/runner_scaler.py#L89"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `__init__`
 
@@ -80,7 +80,7 @@ Construct the object.
 
 ---
 
-<a href="../src/github_runner_manager/manager/runner_scaler.py#L133"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/manager/runner_scaler.py#L137"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `flush`
 
@@ -103,7 +103,7 @@ Flush the runners.
 
 ---
 
-<a href="../src/github_runner_manager/manager/runner_scaler.py#L97"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/manager/runner_scaler.py#L101"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `get_runner_info`
 
@@ -120,7 +120,7 @@ Get information on the runners.
 
 ---
 
-<a href="../src/github_runner_manager/manager/runner_scaler.py#L151"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/manager/runner_scaler.py#L155"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `reconcile`
 

--- a/src-docs/openstack_cloud.openstack_cloud.md
+++ b/src-docs/openstack_cloud.openstack_cloud.md
@@ -9,10 +9,33 @@ Class for accessing OpenStack API for managing servers.
 ---------------
 - **CREATE_SERVER_TIMEOUT**
 
+---
+
+<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L114"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>function</kbd> `catch_openstack_errors`
+
+```python
+catch_openstack_errors(func: Callable[~P, ~T]) → Callable[~P, ~T]
+```
+
+Decorate a function to wrap OpenStack exceptions in a custom exception and log them. 
+
+
+
+**Args:**
+ 
+ - <b>`func`</b>:  The function to decorate. 
+
+
+
+**Returns:**
+ The decorated function. 
+
 
 ---
 
-<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L38"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L39"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `OpenStackCredentials`
 OpenStack credentials. 
@@ -55,7 +78,7 @@ __init__(
 
 ---
 
-<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L61"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L62"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `OpenstackInstance`
 Represents an OpenStack instance. 
@@ -71,7 +94,7 @@ Represents an OpenStack instance.
  - <b>`server_name`</b>:  Name of the server on OpenStack. 
  - <b>`status`</b>:  Status of the server. 
 
-<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L82"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L83"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `__init__`
 
@@ -100,14 +123,14 @@ Construct the object.
 
 ---
 
-<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L143"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L184"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `OpenstackCloud`
 Client to interact with OpenStack cloud. 
 
 The OpenStack server name is managed by this cloud. Caller refers to the instances via instance_id. If the caller needs the server name, e.g., for logging, it can be queried with get_server_name. 
 
-<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L151"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L192"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `__init__`
 
@@ -130,7 +153,7 @@ Create the object.
 
 ---
 
-<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L345"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L391"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `cleanup`
 
@@ -142,7 +165,7 @@ Cleanup unused key files and openstack keypairs.
 
 ---
 
-<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L238"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L281"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `delete_instance`
 
@@ -160,7 +183,7 @@ Delete a openstack instance.
 
 ---
 
-<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L220"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L262"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `get_instance`
 
@@ -183,7 +206,7 @@ Get OpenStack instance by instance ID.
 
 ---
 
-<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L324"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L369"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `get_instances`
 
@@ -200,7 +223,7 @@ Get all OpenStack instances.
 
 ---
 
-<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L353"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L400"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `get_server_name`
 
@@ -223,7 +246,7 @@ Get server name on OpenStack.
 
 ---
 
-<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L271"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L315"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `get_ssh_connection`
 
@@ -253,7 +276,7 @@ Get SSH connection to an OpenStack instance.
 
 ---
 
-<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L167"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L206"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `launch_instance`
 

--- a/src-docs/openstack_cloud.openstack_cloud.md
+++ b/src-docs/openstack_cloud.openstack_cloud.md
@@ -11,7 +11,7 @@ Class for accessing OpenStack API for managing servers.
 
 ---
 
-<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L114"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L113"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `catch_openstack_errors`
 
@@ -35,7 +35,7 @@ Decorate a function to wrap OpenStack exceptions in a custom exception and log t
 
 ---
 
-<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L39"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L38"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `OpenStackCredentials`
 OpenStack credentials. 
@@ -78,7 +78,7 @@ __init__(
 
 ---
 
-<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L62"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L61"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `OpenstackInstance`
 Represents an OpenStack instance. 
@@ -94,7 +94,7 @@ Represents an OpenStack instance.
  - <b>`server_name`</b>:  Name of the server on OpenStack. 
  - <b>`status`</b>:  Status of the server. 
 
-<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L83"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L82"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `__init__`
 
@@ -123,14 +123,14 @@ Construct the object.
 
 ---
 
-<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L184"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L176"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `OpenstackCloud`
 Client to interact with OpenStack cloud. 
 
 The OpenStack server name is managed by this cloud. Caller refers to the instances via instance_id. If the caller needs the server name, e.g., for logging, it can be queried with get_server_name. 
 
-<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L192"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L184"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `__init__`
 
@@ -153,7 +153,7 @@ Create the object.
 
 ---
 
-<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L391"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L383"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `cleanup`
 
@@ -165,7 +165,7 @@ Cleanup unused key files and openstack keypairs.
 
 ---
 
-<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L281"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L273"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `delete_instance`
 
@@ -183,7 +183,7 @@ Delete a openstack instance.
 
 ---
 
-<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L262"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L254"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `get_instance`
 
@@ -206,7 +206,7 @@ Get OpenStack instance by instance ID.
 
 ---
 
-<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L369"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L361"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `get_instances`
 
@@ -223,7 +223,7 @@ Get all OpenStack instances.
 
 ---
 
-<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L400"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L392"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `get_server_name`
 
@@ -246,7 +246,7 @@ Get server name on OpenStack.
 
 ---
 
-<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L315"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L307"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `get_ssh_connection`
 
@@ -276,7 +276,7 @@ Get SSH connection to an OpenStack instance.
 
 ---
 
-<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L206"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L198"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `launch_instance`
 

--- a/src-docs/openstack_cloud.openstack_cloud.md
+++ b/src-docs/openstack_cloud.openstack_cloud.md
@@ -9,29 +9,6 @@ Class for accessing OpenStack API for managing servers.
 ---------------
 - **CREATE_SERVER_TIMEOUT**
 
----
-
-<a href="../src/github_runner_manager/openstack_cloud/openstack_cloud.py#L113"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
-
-## <kbd>function</kbd> `catch_openstack_errors`
-
-```python
-catch_openstack_errors(func: Callable[~P, ~T]) → Callable[~P, ~T]
-```
-
-Decorate a function to wrap OpenStack exceptions in a custom exception and log them. 
-
-
-
-**Args:**
- 
- - <b>`func`</b>:  The function to decorate. 
-
-
-
-**Returns:**
- The decorated function. 
-
 
 ---
 

--- a/src/github_runner_manager/errors.py
+++ b/src/github_runner_manager/errors.py
@@ -73,7 +73,11 @@ class JobNotFoundError(GithubClientError):
     """Represents an error when the job could not be found on GitHub."""
 
 
-class OpenStackError(Exception):
+class CloudError(Exception):
+    """Base class for cloud (as e.g. OpenStack) errors."""
+
+
+class OpenStackError(CloudError):
     """Base class for OpenStack errors."""
 
 

--- a/src/github_runner_manager/errors.py
+++ b/src/github_runner_manager/errors.py
@@ -92,5 +92,6 @@ class SSHError(Exception):
 class KeyfileError(SSHError):
     """Represents missing keyfile for SSH."""
 
+
 class ReconcileError(Exception):
     """Base class for all reconcile errors."""

--- a/src/github_runner_manager/errors.py
+++ b/src/github_runner_manager/errors.py
@@ -91,3 +91,6 @@ class SSHError(Exception):
 
 class KeyfileError(SSHError):
     """Represents missing keyfile for SSH."""
+
+class ReconcileError(Exception):
+    """Base class for all reconcile errors."""

--- a/src/github_runner_manager/manager/runner_scaler.py
+++ b/src/github_runner_manager/manager/runner_scaler.py
@@ -11,7 +11,8 @@ import github_runner_manager.reactive.runner_manager as reactive_runner_manager
 from github_runner_manager.errors import (
     CloudError,
     IssueMetricEventError,
-    MissingServerConfigError, ReconcileError,
+    MissingServerConfigError,
+    ReconcileError,
 )
 from github_runner_manager.manager.cloud_runner_manager import HealthState
 from github_runner_manager.manager.github_runner_manager import GitHubRunnerState

--- a/src/github_runner_manager/manager/runner_scaler.py
+++ b/src/github_runner_manager/manager/runner_scaler.py
@@ -200,6 +200,8 @@ class RunnerScaler:
             )
             _issue_reconciliation_metric(reconcile_metric_data)
 
+        logger.info("Finished reconciliation.")
+
         return reconcile_diff
 
     def _reconcile_non_reactive(self, expected_quantity: int) -> _ReconcileResult:

--- a/src/github_runner_manager/manager/runner_scaler.py
+++ b/src/github_runner_manager/manager/runner_scaler.py
@@ -8,7 +8,11 @@ import time
 from dataclasses import dataclass
 
 import github_runner_manager.reactive.runner_manager as reactive_runner_manager
-from github_runner_manager.errors import IssueMetricEventError, MissingServerConfigError
+from github_runner_manager.errors import (
+    CloudError,
+    IssueMetricEventError,
+    MissingServerConfigError,
+)
 from github_runner_manager.manager.cloud_runner_manager import HealthState
 from github_runner_manager.manager.github_runner_manager import GitHubRunnerState
 from github_runner_manager.manager.runner_manager import (
@@ -180,6 +184,8 @@ class RunnerScaler:
                 reconcile_result = self._reconcile_non_reactive(quantity)
                 reconcile_diff = reconcile_result.runner_diff
                 metric_stats = reconcile_result.metric_stats
+        except CloudError:
+            logger.exception("Failed to reconcile runners.")
         finally:
             runner_list = self._manager.get_runners()
             self._log_runners(runner_list)

--- a/src/github_runner_manager/openstack_cloud/openstack_cloud.py
+++ b/src/github_runner_manager/openstack_cloud/openstack_cloud.py
@@ -389,6 +389,7 @@ class OpenstackCloud:
             self._cleanup_key_files(exclude_list)
             self._cleanup_openstack_keypairs(conn, exclude_list)
 
+    @_catch_openstack_errors
     def get_server_name(self, instance_id: str) -> str:
         """Get server name on OpenStack.
 

--- a/src/github_runner_manager/openstack_cloud/openstack_cloud.py
+++ b/src/github_runner_manager/openstack_cloud/openstack_cloud.py
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 
 """Class for accessing OpenStack API for managing servers."""
-
+import functools
 import logging
 import shutil
 from contextlib import contextmanager
@@ -10,8 +10,9 @@ from dataclasses import dataclass
 from datetime import datetime
 from functools import reduce
 from pathlib import Path
-from typing import Iterable, Iterator, cast
+from typing import Callable, Iterable, Iterator, ParamSpec, TypeVar, cast
 
+import keystoneauth1.exceptions
 import openstack
 import openstack.exceptions
 import paramiko
@@ -106,6 +107,46 @@ class OpenstackInstance:
         self.status = server.status
 
 
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+def catch_openstack_errors(func: Callable[P, T]) -> Callable[P, T]:
+    """Decorate a function to wrap OpenStack exceptions in a custom exception and log them.
+
+    Args:
+        func: The function to decorate.
+
+    Returns:
+        The decorated function.
+    """
+
+    @functools.wraps(func)
+    def exception_handling_wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+        """Wrap the function with exception handling.
+
+        Args:
+            args: The positional arguments.
+            kwargs: The keyword arguments.
+
+        Raises:
+            OpenStackError: If any OpenStack exception is caught.
+
+        Returns:
+            The return value of the decorated function.
+        """
+        try:
+            return func(*args, **kwargs)
+        except (
+            openstack.exceptions.SDKException,
+            keystoneauth1.exceptions.ClientException,
+        ) as exc:
+            logger.exception("OpenStack API call failure")
+            raise OpenStackError("Failed OpenStack API call") from exc
+
+    return exception_handling_wrapper
+
+
 @contextmanager
 @retry(tries=2, delay=5, local_logger=logger)
 def _get_openstack_connection(credentials: OpenStackCredentials) -> Iterator[OpenstackConnection]:
@@ -162,6 +203,7 @@ class OpenstackCloud:
         self._system_user = system_user
         self._ssh_key_dir = Path(f"~{system_user}").expanduser() / ".ssh"
 
+    @catch_openstack_errors
     # Ignore "Too many arguments" as 6 args should be fine. Move to a dataclass if new args are
     # added.
     def launch_instance(  # pylint: disable=too-many-arguments, too-many-positional-arguments
@@ -217,6 +259,7 @@ class OpenstackCloud:
 
             return OpenstackInstance(server, self.prefix)
 
+    @catch_openstack_errors
     def get_instance(self, instance_id: str) -> OpenstackInstance | None:
         """Get OpenStack instance by instance ID.
 
@@ -235,6 +278,7 @@ class OpenstackCloud:
                 return OpenstackInstance(server, self.prefix)
         return None
 
+    @catch_openstack_errors
     def delete_instance(self, instance_id: str) -> None:
         """Delete a openstack instance.
 
@@ -268,6 +312,7 @@ class OpenstackCloud:
         ) as err:
             raise OpenStackError(f"Failed to remove openstack runner {full_name}") from err
 
+    @catch_openstack_errors
     def get_ssh_connection(self, instance: OpenstackInstance) -> SSHConnection:
         """Get SSH connection to an OpenStack instance.
 
@@ -321,6 +366,7 @@ class OpenstackCloud:
             f"addresses: {instance.addresses}"
         )
 
+    @catch_openstack_errors
     def get_instances(self) -> tuple[OpenstackInstance, ...]:
         """Get all OpenStack instances.
 
@@ -342,6 +388,7 @@ class OpenstackCloud:
                 if server is not None
             )
 
+    @catch_openstack_errors
     def cleanup(self) -> None:
         """Cleanup unused key files and openstack keypairs."""
         with _get_openstack_connection(credentials=self._credentials) as conn:

--- a/src/github_runner_manager/openstack_cloud/openstack_cloud.py
+++ b/src/github_runner_manager/openstack_cloud/openstack_cloud.py
@@ -140,7 +140,7 @@ def _catch_openstack_errors(func: Callable[P, T]) -> Callable[P, T]:
             openstack.exceptions.SDKException,
             keystoneauth1.exceptions.ClientException,
         ) as exc:
-            logger.exception("OpenStack API call failure")
+            logger.error("OpenStack API call failure")
             raise OpenStackError("Failed OpenStack API call") from exc
 
     return exception_handling_wrapper

--- a/src/github_runner_manager/openstack_cloud/openstack_cloud.py
+++ b/src/github_runner_manager/openstack_cloud/openstack_cloud.py
@@ -110,7 +110,7 @@ P = ParamSpec("P")
 T = TypeVar("T")
 
 
-def catch_openstack_errors(func: Callable[P, T]) -> Callable[P, T]:
+def _catch_openstack_errors(func: Callable[P, T]) -> Callable[P, T]:
     """Decorate a function to wrap OpenStack exceptions in a custom exception and log them.
 
     Args:
@@ -195,7 +195,7 @@ class OpenstackCloud:
         self._system_user = system_user
         self._ssh_key_dir = Path(f"~{system_user}").expanduser() / ".ssh"
 
-    @catch_openstack_errors
+    @_catch_openstack_errors
     # Ignore "Too many arguments" as 6 args should be fine. Move to a dataclass if new args are
     # added.
     def launch_instance(  # pylint: disable=too-many-arguments, too-many-positional-arguments
@@ -251,7 +251,7 @@ class OpenstackCloud:
 
             return OpenstackInstance(server, self.prefix)
 
-    @catch_openstack_errors
+    @_catch_openstack_errors
     def get_instance(self, instance_id: str) -> OpenstackInstance | None:
         """Get OpenStack instance by instance ID.
 
@@ -270,7 +270,7 @@ class OpenstackCloud:
                 return OpenstackInstance(server, self.prefix)
         return None
 
-    @catch_openstack_errors
+    @_catch_openstack_errors
     def delete_instance(self, instance_id: str) -> None:
         """Delete a openstack instance.
 
@@ -304,7 +304,7 @@ class OpenstackCloud:
         ) as err:
             raise OpenStackError(f"Failed to remove openstack runner {full_name}") from err
 
-    @catch_openstack_errors
+    @_catch_openstack_errors
     def get_ssh_connection(self, instance: OpenstackInstance) -> SSHConnection:
         """Get SSH connection to an OpenStack instance.
 
@@ -358,7 +358,7 @@ class OpenstackCloud:
             f"addresses: {instance.addresses}"
         )
 
-    @catch_openstack_errors
+    @_catch_openstack_errors
     def get_instances(self) -> tuple[OpenstackInstance, ...]:
         """Get all OpenStack instances.
 
@@ -380,7 +380,7 @@ class OpenstackCloud:
                 if server is not None
             )
 
-    @catch_openstack_errors
+    @_catch_openstack_errors
     def cleanup(self) -> None:
         """Cleanup unused key files and openstack keypairs."""
         with _get_openstack_connection(credentials=self._credentials) as conn:

--- a/src/github_runner_manager/openstack_cloud/openstack_cloud.py
+++ b/src/github_runner_manager/openstack_cloud/openstack_cloud.py
@@ -111,7 +111,7 @@ T = TypeVar("T")
 
 
 def _catch_openstack_errors(func: Callable[P, T]) -> Callable[P, T]:
-    """Decorate a function to wrap OpenStack exceptions in a custom exception and log them.
+    """Decorate a function to wrap OpenStack exceptions in a custom exception.
 
     Args:
         func: The function to decorate.

--- a/tests/unit/openstack_cloud/test_openstack_cloud.py
+++ b/tests/unit/openstack_cloud/test_openstack_cloud.py
@@ -1,0 +1,63 @@
+#  Copyright 2024 Canonical Ltd.
+#  See LICENSE file for licensing details.
+from typing import Any
+from unittest.mock import MagicMock
+
+import keystoneauth1.exceptions
+import openstack
+import pytest
+
+from github_runner_manager.errors import OpenStackError
+from github_runner_manager.openstack_cloud.openstack_cloud import (
+    OpenstackCloud,
+    OpenStackCredentials,
+)
+
+FAKE_ARG = "fake"
+
+
+@pytest.mark.parametrize(
+    "public_method, args",
+    [
+        pytest.param("launch_instance", (FAKE_ARG,) * 5, id="launch_instance"),
+        pytest.param("get_instance", (FAKE_ARG,), id="get_instance"),
+        pytest.param("delete_instance", (FAKE_ARG,), id="delete_instance"),
+        pytest.param("get_instances", (), id="get_instances"),
+        pytest.param("cleanup", (), id="cleanup"),
+    ],
+)
+def test_raises_openstack_error(
+    public_method: str, args: tuple[Any, ...], monkeypatch: pytest.MonkeyPatch
+):
+    """
+    arrange: Mock OpenstackCloud and openstack.connect to raise an Openstack api exception.
+    act: Call a public method which connects to Openstack.
+    assert: OpenStackError is raised.
+    """
+    creds = OpenStackCredentials(
+        username=FAKE_ARG,
+        password=FAKE_ARG,
+        project_name=FAKE_ARG,
+        user_domain_name=FAKE_ARG,
+        project_domain_name=FAKE_ARG,
+        auth_url=FAKE_ARG,
+        region_name=FAKE_ARG,
+    )
+    # Mock expanduser as this is used in OpenstackCloud constructor
+    monkeypatch.setattr(
+        "github_runner_manager.openstack_cloud.openstack_cloud.Path.expanduser", MagicMock()
+    )
+
+    cloud = OpenstackCloud(creds, FAKE_ARG, FAKE_ARG)
+    openstack_connect_mock = MagicMock(spec=openstack.connect)
+
+    excs = (openstack.exceptions.SDKException, keystoneauth1.exceptions.ClientException)
+    for exc in excs:
+        openstack_connect_mock.side_effect = exc("an exception occurred")
+        monkeypatch.setattr(
+            "github_runner_manager.openstack_cloud.openstack_cloud.openstack.connect",
+            openstack_connect_mock,
+        )
+        with pytest.raises(OpenStackError) as exc:
+            getattr(cloud, public_method)(*args)
+        assert "Failed OpenStack API call" in str(exc.value)

--- a/tests/unit/test_runner_scaler.py
+++ b/tests/unit/test_runner_scaler.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from github_runner_manager.errors import ReconcileError, CloudError
 from github_runner_manager.manager.cloud_runner_manager import CloudRunnerState, InstanceId
 from github_runner_manager.manager.github_runner_manager import GitHubRunnerState
 from github_runner_manager.manager.runner_manager import (
@@ -202,6 +203,22 @@ def test_reconcile_error_still_issue_metrics(
     issue_events_mock.assert_called_once()
     issued_event = issue_events_mock.call_args[0][0]
     assert isinstance(issued_event, Reconciliation)
+
+
+def test_reconcile_raises_reconcile_error(
+    runner_scaler: RunnerScaler, monkeypatch: pytest.MonkeyPatch, issue_events_mock: MagicMock
+):
+    """
+    Arrange: A RunnerScaler with no runners which raises a Cloud error on reconcile.
+    Act: Reconcile to one runner.
+    Assert: ReconcileError should be raised.
+    """
+    monkeypatch.setattr(
+        runner_scaler._manager, "cleanup", MagicMock(side_effect=CloudError("Mock error"))
+    )
+    with pytest.raises(ReconcileError) as exc:
+        runner_scaler.reconcile(1)
+    assert "Failed to reconcile runners." in str(exc.value)
 
 
 def test_one_runner(runner_scaler: RunnerScaler):

--- a/tests/unit/test_runner_scaler.py
+++ b/tests/unit/test_runner_scaler.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from github_runner_manager.errors import ReconcileError, CloudError
+from github_runner_manager.errors import CloudError, ReconcileError
 from github_runner_manager.manager.cloud_runner_manager import CloudRunnerState, InstanceId
 from github_runner_manager.manager.github_runner_manager import GitHubRunnerState
 from github_runner_manager.manager.runner_manager import (


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Add a decorator to wrap openstack api exceptions into a custom exception which is then caught during reconcile, logged and thrown as `ReconcileError`.  This error can then be caught in charm.py and appropriate action taken (e.g. fail an action or just log the exception and exit for the reconcile event).

Another advantage is that if an error occurs while creating a runner, it will not affect the whole reconcile loop, only that particular runner will not be created (as `OpenstackError` is already caught there).

Integration test run: https://github.com/canonical/github-runner-operator/actions/runs/11727774068?pr=399

### Rationale

We are currently observing ssl exceptions when contacting neutron, which lets the charm error out during reconciliation. Having a custom error with appropriate messages improves troubleshooting, and if the error occurs during runner creation, it will not affect the entire reconciliation.

### Module Changes

Add decorator to public methods in `openstack_cloud.py`

### Library/Dependency Changes

n/a

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The library version in `pyproject.toml` is incremented

<!-- Explanation for any unchecked items above -->
