### PR TITLE
WIP - Catch RunnerCreateError for single spawn

### DIFF
--- a/src-docs/reactive.consumer.md
+++ b/src-docs/reactive.consumer.md
@@ -74,7 +74,7 @@ Log the job details and acknowledge the message. If the job details are invalid,
 
 ---
 
-<a href="../reactive/consumer/signal_handler#L234"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../reactive/consumer/signal_handler#L238"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `signal_handler`
 

--- a/src/github_runner_manager/reactive/consumer.py
+++ b/src/github_runner_manager/reactive/consumer.py
@@ -192,7 +192,11 @@ def _spawn_runner(
     if _check_job_been_picked_up(job_url=job_url, github_client=github_client):
         msg.ack()
         return
-    runner_manager.create_runners(1)
+    instance_ids = runner_manager.create_runners(1)
+    if not instance_ids:
+        logger.error("Failed to spawn a runner. Will reject the message.")
+        msg.reject(requeue=True)
+        return
     for _ in range(10):
         if _check_job_been_picked_up(job_url=job_url, github_client=github_client):
             msg.ack()

--- a/tests/unit/reactive/test_consumer.py
+++ b/tests/unit/reactive/test_consumer.py
@@ -99,9 +99,36 @@ def test_consume_reject_if_job_gets_not_picked_up(queue_config: QueueConfig):
         supported_labels=labels,
     )
 
-    # Ensure message has been requeued by reconsuming it
-    msg = _consume_from_queue(queue_config.queue_name)
-    assert msg.payload == job_details.json()
+    _assert_msg_has_been_requeued(queue_config.queue_name, job_details.json())
+
+
+def test_consume_reject_if_spawning_failed(queue_config: QueueConfig):
+    """
+    arrange: A job placed in the message queue and spawning a runner fails.
+    act: Call consume.
+    assert: The message is requeued.
+    """
+    labels = {secrets.token_hex(16), secrets.token_hex(16)}
+    job_details = consumer.JobDetails(
+        labels=labels,
+        url=FAKE_JOB_URL,
+    )
+    _put_in_queue(job_details.json(), queue_config.queue_name)
+
+    runner_manager_mock = MagicMock(spec=consumer.RunnerManager)
+    runner_manager_mock.create_runners.return_value = tuple()
+
+    github_client_mock = MagicMock(spec=consumer.GithubClient)
+    github_client_mock.get_job_info.return_value = _create_job_info(JobStatus.QUEUED)
+
+    consumer.consume(
+        queue_config=queue_config,
+        runner_manager=runner_manager_mock,
+        github_client=github_client_mock,
+        supported_labels=labels,
+    )
+
+    _assert_msg_has_been_requeued(queue_config.queue_name, job_details.json())
 
 
 def test_consume_raises_queue_error(monkeypatch: pytest.MonkeyPatch, queue_config: QueueConfig):
@@ -291,3 +318,17 @@ def _assert_queue_is_empty(queue_name: str) -> None:
     with Connection(IN_MEMORY_URI) as conn:
         with closing(conn.SimpleQueue(queue_name)) as simple_queue:
             assert simple_queue.qsize() == 0
+
+
+def _assert_msg_has_been_requeued(queue_name: str, payload: str) -> None:
+    """Assert that the message is requeued.
+
+    This will consume message from the queue and assert that the payload is the same as the given.
+
+    Args:
+        queue_name: The name of the queue.
+        msg: The message to assert.
+    """
+    with Connection(IN_MEMORY_URI) as conn:
+        with closing(conn.SimpleQueue(queue_name)) as simple_queue:
+            assert simple_queue.get(block=False).payload == payload


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Catch RunnerCreateError when spawning without multiprocessing.

Integration test run: https://github.com/canonical/github-runner-operator/actions/runs/11839793577

### Rationale

We have observed uncaught charm exceptions due to the error not being caught when not using multiprocessing.

```
2024-11-14 09:53:29.743	
2024-11-14 08:53:29 ERROR unit.openstack-amd64-large-ps6/3.juju-log server.go:325 Uncaught exception while in charm code:

2024-11-14 09:53:29.743	
Traceback (most recent call last):
2024-11-14 09:53:29.743	
  File "/var/lib/juju/agents/unit-openstack-amd64-large-ps6-3/charm/venv/github_runner_manager/openstack_cloud/openstack_cloud.py", line 193, in launch_instance
2024-11-14 09:53:29.743	
    server = conn.create_server(
2024-11-14 09:53:29.743	
  File "/var/lib/juju/agents/unit-openstack-amd64-large-ps6-3/charm/venv/decorator.py", line 232, in fun
2024-11-14 09:53:29.743	
    return caller(func, *(extras + args), **kw)
2024-11-14 09:53:29.743	
  File "/var/lib/juju/agents/unit-openstack-amd64-large-ps6-3/charm/venv/openstack/cloud/_utils.py", line 224, in func_wrapper
2024-11-14 09:53:29.743	
    return func(*args, **kwargs)
2024-11-14 09:53:29.743	
  File "/var/lib/juju/agents/unit-openstack-amd64-large-ps6-3/charm/venv/openstack/cloud/_compute.py", line 1021, in create_server
2024-11-14 09:53:29.743	
    server = self.wait_for_server(
2024-11-14 09:53:29.743	
  File "/var/lib/juju/agents/unit-openstack-amd64-large-ps6-3/charm/venv/openstack/cloud/_compute.py", line 1142, in wait_for_server
2024-11-14 09:53:29.743	
    for count in utils.iterate_timeout(
2024-11-14 09:53:29.743	
  File "/var/lib/juju/agents/unit-openstack-amd64-large-ps6-3/charm/venv/openstack/utils.py", line 73, in iterate_timeout
2024-11-14 09:53:29.743	
    raise exceptions.ResourceTimeout(message)
2024-11-14 09:53:29.743	
openstack.exceptions.ResourceTimeout: Timeout waiting for the server to come up.
2024-11-14 09:53:29.743	

2024-11-14 09:53:29.743	
The above exception was the direct cause of the following exception:
2024-11-14 09:53:29.743	

2024-11-14 09:53:29.743	
Traceback (most recent call last):
2024-11-14 09:53:29.743	
  File "/var/lib/juju/agents/unit-openstack-amd64-large-ps6-3/charm/venv/github_runner_manager/openstack_cloud/openstack_runner_manager.py", line 204, in create_runner
2024-11-14 09:53:29.743	
    instance = self._openstack_cloud.launch_instance(
2024-11-14 09:53:29.743	
  File "/var/lib/juju/agents/unit-openstack-amd64-large-ps6-3/charm/venv/github_runner_manager/openstack_cloud/openstack_cloud.py", line 212, in launch_instance
2024-11-14 09:53:29.743	
    raise OpenStackError(f"Timeout creating openstack server {full_name}") from err
2024-11-14 09:53:29.743	
github_runner_manager.errors.OpenStackError: Timeout creating openstack server openstack-amd64-large-ps6-3-83c0dbcfdfd9
2024-11-14 09:53:29.743	

2024-11-14 09:53:29.743	
The above exception was the direct cause of the following exception:
2024-11-14 09:53:29.743	

2024-11-14 09:53:29.743	
Traceback (most recent call last):
2024-11-14 09:53:29.743	
  File "/var/lib/juju/agents/unit-openstack-amd64-large-ps6-3/charm/./src/charm.py", line 1418, in <module>
2024-11-14 09:53:29.743	
    ops.main(GithubRunnerCharm)
2024-11-14 09:53:29.743	
  File "/var/lib/juju/agents/unit-openstack-amd64-large-ps6-3/charm/venv/ops/__init__.py", line 343, in __call__
2024-11-14 09:53:29.743	
    return _main.main(charm_class=charm_class, use_juju_for_storage=use_juju_for_storage)
2024-11-14 09:53:29.743	
  File "/var/lib/juju/agents/unit-openstack-amd64-large-ps6-3/charm/venv/ops/_main.py", line 543, in main
2024-11-14 09:53:29.743	
    manager.run()
2024-11-14 09:53:29.743	
  File "/var/lib/juju/agents/unit-openstack-amd64-large-ps6-3/charm/venv/ops/_main.py", line 529, in run
2024-11-14 09:53:29.743	
    self._emit()
2024-11-14 09:53:29.743	
  File "/var/lib/juju/agents/unit-openstack-amd64-large-ps6-3/charm/venv/ops/_main.py", line 518, in _emit
2024-11-14 09:53:29.743	
    _emit_charm_event(self.charm, self.dispatcher.event_name, self._juju_context)
2024-11-14 09:53:29.743	
  File "/var/lib/juju/agents/unit-openstack-amd64-large-ps6-3/charm/venv/ops/_main.py", line 134, in _emit_charm_event
2024-11-14 09:53:29.743	
    event_to_emit.emit(*args, **kwargs)
2024-11-14 09:53:29.743	
  File "/var/lib/juju/agents/unit-openstack-amd64-large-ps6-3/charm/venv/ops/framework.py", line 347, in emit
2024-11-14 09:53:29.743	
    framework._emit(event)
2024-11-14 09:53:29.743	
  File "/var/lib/juju/agents/unit-openstack-amd64-large-ps6-3/charm/venv/ops/framework.py", line 857, in _emit
2024-11-14 09:53:29.743	
    self._reemit(event_path)
2024-11-14 09:53:29.743	
  File "/var/lib/juju/agents/unit-openstack-amd64-large-ps6-3/charm/venv/ops/framework.py", line 947, in _reemit
2024-11-14 09:53:29.744	
    custom_handler(event)
2024-11-14 09:53:29.744	
  File "/var/lib/juju/agents/unit-openstack-amd64-large-ps6-3/charm/./src/charm.py", line 148, in func_with_catch_errors
2024-11-14 09:53:29.744	
    func(self, event)
2024-11-14 09:53:29.744	
  File "/var/lib/juju/agents/unit-openstack-amd64-large-ps6-3/charm/./src/charm.py", line 750, in _on_reconcile_runners
2024-11-14 09:53:29.744	
    self._trigger_reconciliation()
2024-11-14 09:53:29.744	
  File "/var/lib/juju/agents/unit-openstack-amd64-large-ps6-3/charm/./src/charm.py", line 771, in _trigger_reconciliation
2024-11-14 09:53:29.744	
    runner_scaler.reconcile(state.runner_config.virtual_machines)
2024-11-14 09:53:29.744	
  File "/var/lib/juju/agents/unit-openstack-amd64-large-ps6-3/charm/venv/github_runner_manager/manager/runner_scaler.py", line 156, in reconcile
2024-11-14 09:53:29.744	
    reconcile_result = self._reconcile_non_reactive(quantity)
2024-11-14 09:53:29.744	
  File "/var/lib/juju/agents/unit-openstack-amd64-large-ps6-3/charm/venv/github_runner_manager/manager/runner_scaler.py", line 185, in _reconcile_non_reactive
2024-11-14 09:53:29.744	
    self._manager.create_runners(runner_diff)
2024-11-14 09:53:29.744	
  File "/var/lib/juju/agents/unit-openstack-amd64-large-ps6-3/charm/venv/github_runner_manager/manager/runner_manager.py", line 138, in create_runners
2024-11-14 09:53:29.744	
    return RunnerManager._spawn_runners(create_runner_args)
2024-11-14 09:53:29.744	
  File "/var/lib/juju/agents/unit-openstack-amd64-large-ps6-3/charm/venv/github_runner_manager/manager/runner_manager.py", line 275, in _spawn_runners
2024-11-14 09:53:29.744	
    return (RunnerManager._create_runner(create_runner_args[0]),)
2024-11-14 09:53:29.744	
  File "/var/lib/juju/agents/unit-openstack-amd64-large-ps6-3/charm/venv/github_runner_manager/manager/runner_manager.py", line 400, in _create_runner
2024-11-14 09:53:29.744	
    return args.cloud_runner_manager.create_runner(registration_token=args.registration_token)
2024-11-14 09:53:29.744	
  File "/var/lib/juju/agents/unit-openstack-amd64-large-ps6-3/charm/venv/github_runner_manager/openstack_cloud/openstack_runner_manager.py", line 212, in create_runner
2024-11-14 09:53:29.744	
    raise RunnerCreateError(f"Failed to create {instance_name} openstack runner") from err
2024-11-14 09:53:29.744	
github_runner_manager.errors.RunnerCreateError: Failed to create openstack-amd64-large-ps6-3-83c0dbcfdfd9 openstack runner
```

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library/Dependency Changes

<!-- Any changes to libraries -->

### Checklist

- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The library version in `pyproject.toml` is incremented

<!-- Explanation for any unchecked items above -->
